### PR TITLE
Object decoder skips property when the value successfully decodes to undefined

### DIFF
--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -241,7 +241,9 @@ export class Decoder<A> {
           if (decoders.hasOwnProperty(key)) {
             const r = decoders[key].decode(json[key]);
             if (r.ok === true) {
-              obj[key] = r.result;
+              if (r.result !== undefined) {
+                obj[key] = r.result;
+              }
             } else {
               return Result.err(prependAt(`.${key}`, r.error));
             }


### PR DESCRIPTION
A value of undefined means that the object property is optional and not
present. Instead of explicitly including the key with a value of undefined, do
not add the key at all.