### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # JSON Type Validation
 
-A typescript library to perform type checking and validation on untyped JSON
-data at runtime.
+A [TypeScript](https://www.typescriptlang.org/) library to perform type checking and validation on untyped JSON data at runtime.
 
 This library owes thanks to:
+
 - [JsonDecoder](https://github.com/aische/JsonDecoder) by Daniel van den Eijkel
 - [Type-safe JSON Decoder](https://github.com/ooesili/type-safe-json-decoder) by Wesley Merkel
 - The Elm [Json.Decode](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode) API
@@ -15,12 +15,13 @@ TODO
 ## Motivation
 
 Let's say we're creating a web app for our pet sitting business, and we've
-picked typescript as one of our core technologies. This is a great choice
-because the extra stability and type safety that typescript provides is really
+picked TypeScript as one of our core technologies. This is a great choice
+because the extra stability and type safety that TypeScript provides is really
 going to help us market our business.
 
 We've defined the data we need to track about each client's pet:
-```
+
+```typescript
 interface Pet {
   name: string;
   species: string;
@@ -30,24 +31,25 @@ interface Pet {
 ```
 
 And we've got some data about current client's pets which is stored as JSON:
-```
-const pet1: Pet = JSON.parse('{"name":"Lyle","species":"Crocodile","isCute":true}')
-const pet2: Pet = JSON.parse('{"name":"Bullwinkle","age":59}')
+
+```typescript
+const croc: Pet = JSON.parse('{"name":"Lyle","species":"Crocodile","isCute":true}')
+const moose: Pet = JSON.parse('{"name":"Bullwinkle","age":59}')
 ```
 
-But that can't be right -- our data for `pet2` is missing information required
-for the `Pet` interface, but typescript compiles the code just fine!
+But that can't be right -- our data for `moose` is missing information required
+for the `Pet` interface, but TypeScript compiles the code just fine!
 
-Of course this isn't an issue with typescript, but with our own type
-annotations. In typescript `JSON.parse` has a return type of `any`, which pushes
+Of course this isn't an issue with TypeScript, but with our own type
+annotations. In TypeScript `JSON.parse` has a return type of `any`, which pushes
 the responsibility of verifying the type of data onto the user. By assuming that
 all of our data is correctly formed, we've left ourselves open to unexpected
 errors at runtime.
 
-Unfortunately typescript doesn't provide a good built-in way to deal with this
-issue. Providing run-time type information is one of typescript's
+Unfortunately TypeScript doesn't provide a good built-in way to deal with this
+issue. Providing run-time type information is one of TypeScript's
 [non-goals](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Design-Goals#non-goals),
-and our web app is too important to risk using a forked version of typescript
+and our web app is too important to risk using a forked version of TypeScript
 with that added functionality.
 [Type guards](https://basarat.gitbooks.io/typescript/docs/types/typeGuard.html)
 work, but are limited in that they circumvent type inference instead of working
@@ -56,7 +58,8 @@ with it, and can be cumbersome to write.
 With `json-type-validation` we can define decoders that validate untyped json
 input. Decoders are concise, composable, and typecheck against our defined types
 and interfaces.
-```
+
+```typescript
 import {Decoder, object, string, optional, number, boolean} from 'json-type-validation'
 
 const petDecoder: Decoder<Pet> = object({
@@ -70,7 +73,8 @@ const petDecoder: Decoder<Pet> = object({
 Finally, we can choose from a number of decoding methods to validate json and
 report success or failure. When some json input fails validation the decoder
 clearly shows how the data was malformed.
-```
+
+```typescript
 const lyle: Pet = petDecoder.runWithException(pet1)
 
 const bullwinkle: Pet = petDecoder.runWithException(pet2)


### PR DESCRIPTION
* Properly capitalize TypeScript (and link the first occurrence to the website. 
* Renamed the variables in the example code to be a little less "coder generic"
* Added proper Markdown spacing around code blocks
* Added code block syntax highlighting markers