### PR TITLE
Upgrade to TypeScript 2.9

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,26 +1,17 @@
 
-# Documentation
+Documentation
+=============
 
 [Documentation](https://github.com/mojotech/json-type-validation/tree/master/docs).
 
-The best places to start are with the examples in the `test/` directory, and the
-documentation for the
-[Decoder class](https://github.com/mojotech/json-type-validation/blob/master/docs/classes/_decoder_.decoder.md).
-At some point you may need documentation for dealing with the
-[Result type](https://github.com/mojotech/json-type-validation/blob/master/docs/modules/_result_.md).
+The best places to start are with the examples in the `test/` directory, and the documentation for the [Decoder class](https://github.com/mojotech/json-type-validation/blob/master/docs/classes/_decoder_.decoder.md). At some point you may need documentation for dealing with the [Result type](https://github.com/mojotech/json-type-validation/blob/master/docs/modules/_result_.md).
 
 ### Type Parameters
 
-Many of the decoder functions take an optional type parameter which determines
-the type of the decoded value. In most cases typescript successfully infers
-these types, although some specific decoders include documentation for
-situations where the type is necessary (see the `constant` and `union`
-decoders). You may still find that including the type parameter improves type
-inference in situations where typescript's error messages are particularly
-unhelpful.
+Many of the decoder functions take an optional type parameter which determines the type of the decoded value. In most cases typescript successfully infers these types, although some specific decoders include documentation for situations where the type is necessary (see the `constant` and `union` decoders). You may still find that including the type parameter improves type inference in situations where typescript's error messages are particularly unhelpful.
 
-As an example, a decoder for the `Pet` interface can be typechecked just as
-effectively using the type parameter as with the `Decoder<Pet>` annotation.
+As an example, a decoder for the `Pet` interface can be typechecked just as effectively using the type parameter as with the `Decoder<Pet>` annotation.
+
 ```
 const petDecoder = object<Pet>({
   name: string(),
@@ -32,16 +23,7 @@ const petDecoder = object<Pet>({
 
 ### Combinators
 
-This library uses the [combinator pattern](https://wiki.haskell.org/Combinator_pattern)
-to build decoders. The decoder primitives `string`, `number`, `boolean`,
-`anyJson`, `constant`, `succeed`, and `fail` act as decoder building blocks that
-each perform a simple decoding operation. The decoder combinators `object`,
-`array`, `dict`, `optional`, `oneOf`, `union`, `withDefault`, `valueAt`, and
-`lazy` take decoders as arguments, and combined the decoders into more
-complicated structures. You can think of your own user-defined decoders as an
-extension of these composable units.
-
-
+This library uses the [combinator pattern](https://wiki.haskell.org/Combinator_pattern) to build decoders. The decoder primitives `string`, `number`, `boolean`, `anyJson`, `constant`, `succeed`, and `fail` act as decoder building blocks that each perform a simple decoding operation. The decoder combinators `object`, `array`, `dict`, `optional`, `oneOf`, `union`, `withDefault`, `valueAt`, and `lazy` take decoders as arguments, and combined the decoders into more complicated structures. You can think of your own user-defined decoders as an extension of these composable units.
 
 ## Index
 
@@ -49,8 +31,8 @@ extension of these composable units.
 
 * ["combinators"](modules/_combinators_.md)
 * ["decoder"](modules/_decoder_.md)
+* ["index"](modules/_index_.md)
 * ["result"](modules/_result_.md)
 
-
-
 ---
+

--- a/docs/classes/_decoder_.decoder.md
+++ b/docs/classes/_decoder_.decoder.md
@@ -1,9 +1,6 @@
 [@mojotech/json-type-validation](../README.md) > ["decoder"](../modules/_decoder_.md) > [Decoder](../classes/_decoder_.decoder.md)
 
-
-
 # Class: Decoder
-
 
 Decoders transform json objects with unknown structure into known and verified forms. You can create objects of type `Decoder<A>` with either the primitive decoder functions, such as `boolean()` and `string()`, or by applying higher-order decoders to the primitives, such as `array(boolean())` or `dict(string())`.
 
@@ -15,7 +12,19 @@ Alternatively, the main decoder `run()` method returns an object of type `Result
 
 ## Type parameters
 #### A 
+## Hierarchy
+
+**Decoder**
+
 ## Index
+
+### Constructors
+
+* [constructor](_decoder_.decoder.md#constructor)
+
+### Properties
+
+* [decode](_decoder_.decoder.md#decode)
 
 ### Methods
 
@@ -41,271 +50,227 @@ Alternatively, the main decoder `run()` method returns an object of type `Result
 * [valueAt](_decoder_.decoder.md#valueat)
 * [withDefault](_decoder_.decoder.md#withdefault)
 
-
-
 ---
 
+## Constructors
+
+<a id="constructor"></a>
+
+### `<Private>` constructor
+
+⊕ **new Decoder**(decode: *`function`*): [Decoder](_decoder_.decoder.md)
+
+The Decoder class constructor is kept private to separate the internal `decode` function from the external `run` function. The distinction between the two functions is that `decode` returns a `Partial<DecoderError>` on failure, which contains an unfinished error report. When `run` is called on a decoder, the relevant series of `decode` calls is made, and then on failure the resulting `Partial<DecoderError>` is turned into a `DecoderError` by filling in the missing informaiton.
+
+While hiding the constructor may seem restrictive, leveraging the provided decoder combinators and helper functions such as `andThen` and `map` should be enough to build specialized decoders as needed.
+
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| decode | `function` |
+
+**Returns:** [Decoder](_decoder_.decoder.md)
+
+___
+
+## Properties
+
+<a id="decode"></a>
+
+### `<Private>` decode
+
+**● decode**: *`function`*
+
+#### Type declaration
+▸(json: *`any`*): `Result.Result`<`A`, `Partial`<[DecoderError](../interfaces/_decoder_.decodererror.md)>>
+
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| json | `any` |
+
+**Returns:** `Result.Result`<`A`, `Partial`<[DecoderError](../interfaces/_decoder_.decodererror.md)>>
+
+___
 
 ## Methods
+
 <a id="andthen"></a>
 
 ###  andThen
 
-► **andThen**B(f: *`function`*): [Decoder](_decoder_.decoder.md)`B`
-
-
-
-
-
+▸ **andThen**B(f: *`function`*): [Decoder](_decoder_.decoder.md)<`B`>
 
 Chain together a sequence of decoders. The first decoder will run, and then the function will determine what decoder to run second. If the result of the first decoder succeeds then `f` will be applied to the decoded value. If it fails the error will propagate through. One use case for `andThen` is returning a custom error message.
 
 Example:
 
-    const versionDecoder = valueAt(['version'], number());
-    const infoDecoder3 = object({a: boolean()});
+```
+const versionDecoder = valueAt(['version'], number());
+const infoDecoder3 = object({a: boolean()});
 
-    const decoder = versionDecoder.andThen(version => {
-      switch (version) {
-        case 3:
-          return infoDecoder3;
-        default:
-          return fail(`Unable to decode info, version ${version} is not supported.`);
-      }
-    });
+const decoder = versionDecoder.andThen(version => {
+  switch (version) {
+    case 3:
+      return infoDecoder3;
+    default:
+      return fail(`Unable to decode info, version ${version} is not supported.`);
+  }
+});
 
-    decoder.run({version: 3, a: true})
-    // => {ok: true, result: {a: true}}
+decoder.run({version: 3, a: true})
+// => {ok: true, result: {a: true}}
 
-    decoder.run({version: 5, x: 'abc'})
-    // =>
-    // {
-    //   ok: false,
-    //   error: {
-    //     ...
-    //     at: 'input',
-    //     message: 'Unable to decode info, version 5 is not supported.'
-    //   }
-    // }
-
+decoder.run({version: 5, x: 'abc'})
+// =>
+// {
+//   ok: false,
+//   error: {
+//     ...
+//     at: 'input',
+//     message: 'Unable to decode info, version 5 is not supported.'
+//   }
+// }
+```
 
 **Type parameters:**
 
 #### B 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| f | `function`   |  - |
+| Param | Type |
+| ------ | ------ |
+| f | `function` |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`B`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`B`>
 
 ___
-
 <a id="map"></a>
 
 ###  map
 
-► **map**B(f: *`function`*): [Decoder](_decoder_.decoder.md)`B`
-
-
-
-
-
+▸ **map**B(f: *`function`*): [Decoder](_decoder_.decoder.md)<`B`>
 
 Construct a new decoder that applies a transformation to the decoded result. If the decoder succeeds then `f` will be applied to the value. If it fails the error will propagated through.
 
 Example:
 
-    number().map(x => x * 5).run(10)
-    // => {ok: true, result: 50}
-
+```
+number().map(x => x * 5).run(10)
+// => {ok: true, result: 50}
+```
 
 **Type parameters:**
 
 #### B 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| f | `function`   |  - |
+| Param | Type |
+| ------ | ------ |
+| f | `function` |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`B`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`B`>
 
 ___
-
 <a id="run"></a>
 
 ###  run
 
-► **run**(json: *`any`*): `Result.Result`.<`A`>,.<[DecoderError](../interfaces/_decoder_.decodererror.md)>
-
-
-
-
-
+▸ **run**(json: *`any`*): `Result.Result`<`A`, [DecoderError](../interfaces/_decoder_.decodererror.md)>
 
 Run the decoder and return a `Result` with either the decoded value or a `DecoderError` containing the json input, the location of the error, and the error message.
 
 Examples:
 
-    number().run(12)
-    // => {ok: true, result: 12}
+```
+number().run(12)
+// => {ok: true, result: 12}
 
-    string().run(9001)
-    // =>
-    // {
-    //   ok: false,
-    //   error: {
-    //     kind: 'DecoderError',
-    //     input: 9001,
-    //     at: 'input',
-    //     message: 'expected a string, got 9001'
-    //   }
-    // }
-
+string().run(9001)
+// =>
+// {
+//   ok: false,
+//   error: {
+//     kind: 'DecoderError',
+//     input: 9001,
+//     at: 'input',
+//     message: 'expected a string, got 9001'
+//   }
+// }
+```
 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| json | `any`   |  - |
+| Param | Type |
+| ------ | ------ |
+| json | `any` |
 
-
-
-
-
-**Returns:** `Result.Result`.<`A`>,.<[DecoderError](../interfaces/_decoder_.decodererror.md)>
-
-
-
-
+**Returns:** `Result.Result`<`A`, [DecoderError](../interfaces/_decoder_.decodererror.md)>
 
 ___
-
 <a id="runpromise"></a>
 
 ###  runPromise
 
-► **runPromise**(json: *`any`*): `Promise`.<`A`>
-
-
-
-
-
+▸ **runPromise**(json: *`any`*): `Promise`<`A`>
 
 Run the decoder as a `Promise`.
 
-
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| json | `any`   |  - |
+| Param | Type |
+| ------ | ------ |
+| json | `any` |
 
-
-
-
-
-**Returns:** `Promise`.<`A`>
-
-
-
-
+**Returns:** `Promise`<`A`>
 
 ___
-
 <a id="runwithexception"></a>
 
 ###  runWithException
 
-► **runWithException**(json: *`any`*): `A`
-
-
-
-
-
+▸ **runWithException**(json: *`any`*): `A`
 
 Run the decoder and return the value on success, or throw an exception with a formatted error string.
 
-
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| json | `any`   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| json | `any` |
 
 **Returns:** `A`
 
-
-
-
-
 ___
-
 <a id="anyjson"></a>
 
-### «Static» anyJson
+### `<Static>` anyJson
 
-► **anyJson**(): [Decoder](_decoder_.decoder.md)`any`
-
-
-
-
-
+▸ **anyJson**(): [Decoder](_decoder_.decoder.md)<`any`>
 
 Decoder identity function. Useful for incremental decoding.
 
 Example:
 
-    const json: any = [1, true, 2, 3, 'five', 4, []];
-    const jsonArray: any[] = Result.withDefault([], array(anyJson()).run(json));
-    const numbers: number[] = Result.successes(jsonArray.map(number().run));
+```
+const json: any = [1, true, 2, 3, 'five', 4, []];
+const jsonArray: any[] = Result.withDefault([], array(anyJson()).run(json));
+const numbers: number[] = Result.successes(jsonArray.map(number().run));
 
-    numbers
-    // => [1, 2, 3, 4]
+numbers
+// => [1, 2, 3, 4]
+```
 
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`any`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`any`>
 
 ___
-
 <a id="array"></a>
 
-### «Static» array
+### `<Static>` array
 
-► **array**A(decoder: *[Decoder](_decoder_.decoder.md)`A`*): [Decoder](_decoder_.decoder.md)`A`[]
-
-
-
-
-
+▸ **array**A(decoder: *[Decoder](_decoder_.decoder.md)<`A`>*): [Decoder](_decoder_.decoder.md)<`A`[]>
 
 Decoder for json arrays. Runs `decoder` on each array element, and succeeds if all elements are successfully decoded.
 
@@ -313,72 +278,46 @@ To decode a single value that is inside of an array see `valueAt`.
 
 Examples:
 
-    array(number()).run([1, 2, 3])
-    // => {ok: true, result: [1, 2, 3]}
+```
+array(number()).run([1, 2, 3])
+// => {ok: true, result: [1, 2, 3]}
 
-    array(array(boolean())).run([[true], [], [true, false, false]])
-    // => {ok: true, result: [[true], [], [true, false, false]]}
-
+array(array(boolean())).run([[true], [], [true, false, false]])
+// => {ok: true, result: [[true], [], [true, false, false]]}
+```
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoder | [Decoder](_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoder | [Decoder](_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`[]
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`[]>
 
 ___
-
 <a id="boolean"></a>
 
-### «Static» boolean
+### `<Static>` boolean
 
-► **boolean**(): [Decoder](_decoder_.decoder.md)`boolean`
-
-
-
-
-
+▸ **boolean**(): [Decoder](_decoder_.decoder.md)<`boolean`>
 
 Decoder primitive that validates booleans, and fails on all other input.
 
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`boolean`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`boolean`>
 
 ___
-
 <a id="constant"></a>
 
-### «Static» constant
+### `<Static>` constant
 
-► **constant**(value: *`true`*): [Decoder](_decoder_.decoder.md)`true`
+▸ **constant**(value: *`true`*): [Decoder](_decoder_.decoder.md)<`true`>
 
-► **constant**(value: *`false`*): [Decoder](_decoder_.decoder.md)`false`
+▸ **constant**(value: *`false`*): [Decoder](_decoder_.decoder.md)<`false`>
 
-► **constant**A(value: *`A`*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **constant**A(value: *`A`*): [Decoder](_decoder_.decoder.md)<`A`>
 
 Decoder primitive that only matches on exact values.
 
@@ -386,269 +325,188 @@ Note that `constant('string to match')` returns a `Decoder<string>` which fails 
 
 Providing the type parameter is only necessary for type-literal strings and numbers, as detailed by this table:
 
-     | Decoder                      | Type                 |
-     | ---------------------------- | ---------------------|
-     | constant(true)               | Decoder<true>        |
-     | constant(false)              | Decoder<false>       |
-     | constant(null)               | Decoder<null>        |
-     | constant('alaska')           | Decoder<string>      |
-     | constant<'alaska'>('alaska') | Decoder<'alaska'>    |
-     | constant(50)                 | Decoder<number>      |
-     | constant<50>(50)             | Decoder<50>          |
-     | constant([1,2,3])            | Decoder<number[]>    |
-     | constant<[1,2,3]>([1,2,3])   | Decoder<[1,2,3]>     |
-     | constant({x: 't'})           | Decoder<{x: string}> |
-     | constant<{x: 't'}>({x: 't'}) | Decoder<{x: 't'}>    |
+```
+| Decoder                      | Type                 |
+ | ---------------------------- | ---------------------|
+ | constant(true)               | Decoder<true>        |
+ | constant(false)              | Decoder<false>       |
+ | constant(null)               | Decoder<null>        |
+ | constant('alaska')           | Decoder<string>      |
+ | constant<'alaska'>('alaska') | Decoder<'alaska'>    |
+ | constant(50)                 | Decoder<number>      |
+ | constant<50>(50)             | Decoder<50>          |
+ | constant([1,2,3])            | Decoder<number[]>    |
+ | constant<[1,2,3]>([1,2,3])   | Decoder<[1,2,3]>     |
+ | constant({x: 't'})           | Decoder<{x: string}> |
+ | constant<{x: 't'}>({x: 't'}) | Decoder<{x: 't'}>    |
+```
 
 One place where this happens is when a type-literal is in an interface:
 
-    interface Bear {
-      kind: 'bear';
-      isBig: boolean;
-    }
+```
+interface Bear {
+  kind: 'bear';
+  isBig: boolean;
+}
 
-    const bearDecoder1: Decoder<Bear> = object({
-      kind: constant('bear'),
-      isBig: boolean()
-    });
-    // Type 'Decoder<{ kind: string; isBig: boolean; }>' is not assignable to
-    // type 'Decoder<Bear>'. Type 'string' is not assignable to type '"bear"'.
+const bearDecoder1: Decoder<Bear> = object({
+  kind: constant('bear'),
+  isBig: boolean()
+});
+// Type 'Decoder<{ kind: string; isBig: boolean; }>' is not assignable to
+// type 'Decoder<Bear>'. Type 'string' is not assignable to type '"bear"'.
 
-    const bearDecoder2: Decoder<Bear> = object({
-      kind: constant<'bear'>('bear'),
-      isBig: boolean()
-    });
-    // no compiler errors
+const bearDecoder2: Decoder<Bear> = object({
+  kind: constant<'bear'>('bear'),
+  isBig: boolean()
+});
+// no compiler errors
+```
 
 Another is in type-literal unions:
 
-    type animal = 'bird' | 'bear';
+```
+type animal = 'bird' | 'bear';
 
-    const animalDecoder1: Decoder<animal> = union(
-      constant('bird'),
-      constant('bear')
-    );
-    // Type 'Decoder<string>' is not assignable to type 'Decoder<animal>'.
-    // Type 'string' is not assignable to type 'animal'.
+const animalDecoder1: Decoder<animal> = union(
+  constant('bird'),
+  constant('bear')
+);
+// Type 'Decoder<string>' is not assignable to type 'Decoder<animal>'.
+// Type 'string' is not assignable to type 'animal'.
 
-    const animalDecoder2: Decoder<animal> = union(
-      constant<'bird'>('bird'),
-      constant<'bear'>('bear')
-    );
-    // no compiler errors
-
-
-**Parameters:**
-
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| value | `true`   |  - |
-
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`true`
-
-
-
-
-
+const animalDecoder2: Decoder<animal> = union(
+  constant<'bird'>('bird'),
+  constant<'bear'>('bear')
+);
+// no compiler errors
+```
 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| value | `false`   |  - |
+| Param | Type |
+| ------ | ------ |
+| value | `true` |
 
+**Returns:** [Decoder](_decoder_.decoder.md)<`true`>
 
+**Parameters:**
 
+| Param | Type |
+| ------ | ------ |
+| value | `false` |
 
-
-**Returns:** [Decoder](_decoder_.decoder.md)`false`
-
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`false`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| value | `A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| value | `A` |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="dict"></a>
 
-### «Static» dict
+### `<Static>` dict
 
-► **dict**A(decoder: *[Decoder](_decoder_.decoder.md)`A`*): [Decoder](_decoder_.decoder.md)`object`
-
-
-
-
-
+▸ **dict**A(decoder: *[Decoder](_decoder_.decoder.md)<`A`>*): [Decoder](_decoder_.decoder.md)<`object`>
 
 Decoder for json objects where the keys are unknown strings, but the values should all be of the same type.
 
 Example:
 
-    dict(number()).run({chocolate: 12, vanilla: 10, mint: 37});
-    // => {ok: true, result: {chocolate: 12, vanilla: 10, mint: 37}}
-
+```
+dict(number()).run({chocolate: 12, vanilla: 10, mint: 37});
+// => {ok: true, result: {chocolate: 12, vanilla: 10, mint: 37}}
+```
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoder | [Decoder](_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoder | [Decoder](_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`object`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`object`>
 
 ___
-
 <a id="fail"></a>
 
-### «Static» fail
+### `<Static>` fail
 
-► **fail**A(errorMessage: *`string`*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **fail**A(errorMessage: *`string`*): [Decoder](_decoder_.decoder.md)<`A`>
 
 Decoder that ignores the input json and always fails with `errorMessage`.
 
-
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| errorMessage | `string`   |  - |
+| Param | Type |
+| ------ | ------ |
+| errorMessage | `string` |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="lazy"></a>
 
-### «Static» lazy
+### `<Static>` lazy
 
-► **lazy**A(mkDecoder: *`function`*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **lazy**A(mkDecoder: *`function`*): [Decoder](_decoder_.decoder.md)<`A`>
 
 Decoder that allows for validating recursive data structures. Unlike with functions, decoders assigned to variables can't reference themselves before they are fully defined. We can avoid prematurely referencing the decoder by wrapping it in a function that won't be called until use, at which point the decoder has been defined.
 
 Example:
 
-    interface Comment {
-      msg: string;
-      replies: Comment[];
-    }
+```
+interface Comment {
+  msg: string;
+  replies: Comment[];
+}
 
-    const decoder: Decoder<Comment> = object({
-      msg: string(),
-      replies: lazy(() => array(decoder))
-    });
-
+const decoder: Decoder<Comment> = object({
+  msg: string(),
+  replies: lazy(() => array(decoder))
+});
+```
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| mkDecoder | `function`   |  - |
+| Param | Type |
+| ------ | ------ |
+| mkDecoder | `function` |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="number"></a>
 
-### «Static» number
+### `<Static>` number
 
-► **number**(): [Decoder](_decoder_.decoder.md)`number`
-
-
-
-
-
+▸ **number**(): [Decoder](_decoder_.decoder.md)<`number`>
 
 Decoder primitive that validates numbers, and fails on all other input.
 
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`number`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`number`>
 
 ___
-
 <a id="object"></a>
 
-### «Static» object
+### `<Static>` object
 
-► **object**A(decoders: *[DecoderObject](../modules/_decoder_.md#decoderobject)`A`*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **object**A(decoders: *[DecoderObject](../modules/_decoder_.md#decoderobject)<`A`>*): [Decoder](_decoder_.decoder.md)<`A`>
 
 An higher-order decoder that runs decoders on specified fields of an object, and returns a new object with those fields.
 
@@ -658,41 +516,28 @@ To decode a single field that is inside of an object see `valueAt`.
 
 Example:
 
-    object({x: number(), y: number()}).run({x: 5, y: 10})
-    // => {ok: true, result: {x: 5, y: 10}}
-
+```
+object({x: number(), y: number()}).run({x: 5, y: 10})
+// => {ok: true, result: {x: 5, y: 10}}
+```
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoders | [DecoderObject](../modules/_decoder_.md#decoderobject)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoders | [DecoderObject](../modules/_decoder_.md#decoderobject)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="oneof"></a>
 
-### «Static» oneOf
+### `<Static>` oneOf
 
-► **oneOf**A(...decoders: *[Decoder](_decoder_.decoder.md)`A`[]*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **oneOf**A(...decoders: *[Decoder](_decoder_.decoder.md)<`A`>[]*): [Decoder](_decoder_.decoder.md)<`A`>
 
 Decoder that attempts to run each decoder in `decoders` and either succeeds with the first successful decoder, or fails after all decoders have failed.
 
@@ -700,159 +545,105 @@ Note that `oneOf` expects the decoders to all have the same return type, while `
 
 Examples:
 
-    oneOf(string(), number().map(String))
-    oneOf(constant('start'), constant('stop'), succeed('unknown'))
-
+```
+oneOf(string(), number().map(String))
+oneOf(constant('start'), constant('stop'), succeed('unknown'))
+```
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoders | [Decoder](_decoder_.decoder.md)`A`[]   |  - |
+| Param | Type |
+| ------ | ------ |
+| `Rest` decoders | [Decoder](_decoder_.decoder.md)<`A`>[] |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="optional"></a>
 
-### «Static» optional
+### `<Static>` optional
 
-► **optional**A(decoder: *[Decoder](_decoder_.decoder.md)`A`*): [Decoder](_decoder_.decoder.md)`undefined`⎮`A`
-
-
-
-
-
+▸ **optional**A(decoder: *[Decoder](_decoder_.decoder.md)<`A`>*): [Decoder](_decoder_.decoder.md)< `undefined` &#124; `A`>
 
 Decoder for values that may be `undefined`. This is primarily helpful for decoding interfaces with optional fields.
 
 Example:
 
-    interface User {
-      id: number;
-      isOwner?: boolean;
-    }
+```
+interface User {
+  id: number;
+  isOwner?: boolean;
+}
 
-    const decoder: Decoder<User> = object({
-      id: number(),
-      isOwner: optional(boolean())
-    });
-
+const decoder: Decoder<User> = object({
+  id: number(),
+  isOwner: optional(boolean())
+});
+```
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoder | [Decoder](_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoder | [Decoder](_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`undefined`⎮`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `undefined` &#124; `A`>
 
 ___
-
 <a id="string"></a>
 
-### «Static» string
+### `<Static>` string
 
-► **string**(): [Decoder](_decoder_.decoder.md)`string`
-
-
-
-
-
+▸ **string**(): [Decoder](_decoder_.decoder.md)<`string`>
 
 Decoder primitive that validates strings, and fails on all other input.
 
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`string`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`string`>
 
 ___
-
 <a id="succeed"></a>
 
-### «Static» succeed
+### `<Static>` succeed
 
-► **succeed**A(fixedValue: *`A`*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **succeed**A(fixedValue: *`A`*): [Decoder](_decoder_.decoder.md)<`A`>
 
 Decoder that ignores the input json and always succeeds with `fixedValue`.
-
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| fixedValue | `A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| fixedValue | `A` |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="union"></a>
 
-### «Static» union
+### `<Static>` union
 
-► **union**A,B(ad: *[Decoder](_decoder_.decoder.md)`A`*, bd: *[Decoder](_decoder_.decoder.md)`B`*): [Decoder](_decoder_.decoder.md)`A`⎮`B`
+▸ **union**A,B(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*): [Decoder](_decoder_.decoder.md)< `A` &#124; `B`>
 
-► **union**A,B,C(ad: *[Decoder](_decoder_.decoder.md)`A`*, bd: *[Decoder](_decoder_.decoder.md)`B`*, cd: *[Decoder](_decoder_.decoder.md)`C`*): [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`
+▸ **union**A,B,C(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*): [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C`>
 
-► **union**A,B,C,D(ad: *[Decoder](_decoder_.decoder.md)`A`*, bd: *[Decoder](_decoder_.decoder.md)`B`*, cd: *[Decoder](_decoder_.decoder.md)`C`*, dd: *[Decoder](_decoder_.decoder.md)`D`*): [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`
+▸ **union**A,B,C,D(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*): [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D`>
 
-► **union**A,B,C,D,E(ad: *[Decoder](_decoder_.decoder.md)`A`*, bd: *[Decoder](_decoder_.decoder.md)`B`*, cd: *[Decoder](_decoder_.decoder.md)`C`*, dd: *[Decoder](_decoder_.decoder.md)`D`*, ed: *[Decoder](_decoder_.decoder.md)`E`*): [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`
+▸ **union**A,B,C,D,E(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*): [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E`>
 
-► **union**A,B,C,D,E,F(ad: *[Decoder](_decoder_.decoder.md)`A`*, bd: *[Decoder](_decoder_.decoder.md)`B`*, cd: *[Decoder](_decoder_.decoder.md)`C`*, dd: *[Decoder](_decoder_.decoder.md)`D`*, ed: *[Decoder](_decoder_.decoder.md)`E`*, fd: *[Decoder](_decoder_.decoder.md)`F`*): [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`
+▸ **union**A,B,C,D,E,F(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*, fd: *[Decoder](_decoder_.decoder.md)<`F`>*): [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F`>
 
-► **union**A,B,C,D,E,F,G(ad: *[Decoder](_decoder_.decoder.md)`A`*, bd: *[Decoder](_decoder_.decoder.md)`B`*, cd: *[Decoder](_decoder_.decoder.md)`C`*, dd: *[Decoder](_decoder_.decoder.md)`D`*, ed: *[Decoder](_decoder_.decoder.md)`E`*, fd: *[Decoder](_decoder_.decoder.md)`F`*, gd: *[Decoder](_decoder_.decoder.md)`G`*): [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`
+▸ **union**A,B,C,D,E,F,G(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*, fd: *[Decoder](_decoder_.decoder.md)<`F`>*, gd: *[Decoder](_decoder_.decoder.md)<`G`>*): [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G`>
 
-► **union**A,B,C,D,E,F,G,H(ad: *[Decoder](_decoder_.decoder.md)`A`*, bd: *[Decoder](_decoder_.decoder.md)`B`*, cd: *[Decoder](_decoder_.decoder.md)`C`*, dd: *[Decoder](_decoder_.decoder.md)`D`*, ed: *[Decoder](_decoder_.decoder.md)`E`*, fd: *[Decoder](_decoder_.decoder.md)`F`*, gd: *[Decoder](_decoder_.decoder.md)`G`*, hd: *[Decoder](_decoder_.decoder.md)`H`*): [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`⎮`H`
-
-
-
-
-
+▸ **union**A,B,C,D,E,F,G,H(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*, fd: *[Decoder](_decoder_.decoder.md)<`F`>*, gd: *[Decoder](_decoder_.decoder.md)<`G`>*, hd: *[Decoder](_decoder_.decoder.md)<`H`>*): [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G` &#124; `H`>
 
 Combines 2-8 decoders of disparate types into a decoder for the union of all the types.
 
@@ -860,11 +651,12 @@ If you need more than 8 variants for your union, it's possible to use `oneOf` in
 
 Example:
 
-    type C = {a: string} | {b: number};
+```
+type C = {a: string} | {b: number};
 
-    const unionDecoder: Decoder<C> = union(object({a: string()}), object({b: number()}));
-    const oneOfDecoder: Decoder<C> = oneOf(object<C>({a: string()}), object<C>({b: number()}));
-
+const unionDecoder: Decoder<C> = union(object({a: string()}), object({b: number()}));
+const oneOfDecoder: Decoder<C> = oneOf(object<C>({a: string()}), object<C>({b: number()}));
+```
 
 **Type parameters:**
 
@@ -872,21 +664,12 @@ Example:
 #### B 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](_decoder_.decoder.md)`B`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`⎮`B`
-
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` &#124; `B`>
 
 **Type parameters:**
 
@@ -895,22 +678,13 @@ Example:
 #### C 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](_decoder_.decoder.md)`C`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`
-
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C`>
 
 **Type parameters:**
 
@@ -920,23 +694,14 @@ Example:
 #### D 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](_decoder_.decoder.md)`D`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`
-
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D`>
 
 **Type parameters:**
 
@@ -947,24 +712,15 @@ Example:
 #### E 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](_decoder_.decoder.md)`E`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`
-
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E`>
 
 **Type parameters:**
 
@@ -976,25 +732,16 @@ Example:
 #### F 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](_decoder_.decoder.md)`E`   |  - |
-| fd | [Decoder](_decoder_.decoder.md)`F`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](_decoder_.decoder.md)<`F`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`
-
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F`>
 
 **Type parameters:**
 
@@ -1007,26 +754,17 @@ Example:
 #### G 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](_decoder_.decoder.md)`E`   |  - |
-| fd | [Decoder](_decoder_.decoder.md)`F`   |  - |
-| gd | [Decoder](_decoder_.decoder.md)`G`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](_decoder_.decoder.md)<`F`> |
+| gd | [Decoder](_decoder_.decoder.md)<`G`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`
-
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G`>
 
 **Type parameters:**
 
@@ -1040,122 +778,87 @@ Example:
 #### H 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](_decoder_.decoder.md)`E`   |  - |
-| fd | [Decoder](_decoder_.decoder.md)`F`   |  - |
-| gd | [Decoder](_decoder_.decoder.md)`G`   |  - |
-| hd | [Decoder](_decoder_.decoder.md)`H`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](_decoder_.decoder.md)<`F`> |
+| gd | [Decoder](_decoder_.decoder.md)<`G`> |
+| hd | [Decoder](_decoder_.decoder.md)<`H`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`⎮`H`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G` &#124; `H`>
 
 ___
-
 <a id="valueat"></a>
 
-### «Static» valueAt
+### `<Static>` valueAt
 
-► **valueAt**A(paths: *(`string`⎮`number`)[]*, decoder: *[Decoder](_decoder_.decoder.md)`A`*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **valueAt**A(paths: *( `string` &#124; `number`)[]*, decoder: *[Decoder](_decoder_.decoder.md)<`A`>*): [Decoder](_decoder_.decoder.md)<`A`>
 
 Decoder that pulls a specific field out of a json structure, instead of decoding and returning the full structure. The `paths` array describes the object keys and array indices to traverse, so that values can be pulled out of a nested structure.
 
 Example:
 
-    const decoder = valueAt(['a', 'b', 0], string());
+```
+const decoder = valueAt(['a', 'b', 0], string());
 
-    decoder.run({a: {b: ['surprise!']}})
-    // => {ok: true, result: 'surprise!'}
+decoder.run({a: {b: ['surprise!']}})
+// => {ok: true, result: 'surprise!'}
 
-    decoder.run({a: {x: 'cats'}})
-    // => {ok: false, error: {... at: 'input.a.b[0]' message: 'path does not exist'}}
+decoder.run({a: {x: 'cats'}})
+// => {ok: false, error: {... at: 'input.a.b[0]' message: 'path does not exist'}}
+```
 
 Note that the `decoder` is ran on the value found at the last key in the path, even if the last key is not found. This allows the `optional` decoder to succeed when appropriate.
 
-    const optionalDecoder = valueAt(['a', 'b', 'c'], optional(string()));
+```
+const optionalDecoder = valueAt(['a', 'b', 'c'], optional(string()));
 
-    optionalDecoder.run({a: {b: {c: 'surprise!'}}})
-    // => {ok: true, result: 'surprise!'}
+optionalDecoder.run({a: {b: {c: 'surprise!'}}})
+// => {ok: true, result: 'surprise!'}
 
-    optionalDecoder.run({a: {b: 'cats'}})
-    // => {ok: false, error: {... at: 'input.a.b.c' message: 'expected an object, got "cats"'}
+optionalDecoder.run({a: {b: 'cats'}})
+// => {ok: false, error: {... at: 'input.a.b.c' message: 'expected an object, got "cats"'}
 
-    optionalDecoder.run({a: {b: {z: 1}}})
-    // => {ok: true, result: undefined}
-
+optionalDecoder.run({a: {b: {z: 1}}})
+// => {ok: true, result: undefined}
+```
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| paths | (`string`⎮`number`)[]   |  - |
-| decoder | [Decoder](_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| paths | ( `string` &#124; `number`)[] |
+| decoder | [Decoder](_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="withdefault"></a>
 
-### «Static» withDefault
+### `<Static>` withDefault
 
-► **withDefault**A(defaultValue: *`A`*, decoder: *[Decoder](_decoder_.decoder.md)`A`*): [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **withDefault**A(defaultValue: *`A`*, decoder: *[Decoder](_decoder_.decoder.md)<`A`>*): [Decoder](_decoder_.decoder.md)<`A`>
 
 Decoder that always succeeds with either the decoded value, or a fallback default value.
 
-
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| defaultValue | `A`   |  - |
-| decoder | [Decoder](_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| defaultValue | `A` |
+| decoder | [Decoder](_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
-
 

--- a/docs/interfaces/_decoder_.decodererror.md
+++ b/docs/interfaces/_decoder_.decodererror.md
@@ -1,64 +1,52 @@
 [@mojotech/json-type-validation](../README.md) > ["decoder"](../modules/_decoder_.md) > [DecoderError](../interfaces/_decoder_.decodererror.md)
 
-
-
 # Interface: DecoderError
-
 
 Information describing how json data failed to match a decoder. Includes the full input json, since in most cases it's useless to know how a decoder failed without also seeing the malformed data.
 
+## Hierarchy
+
+**DecoderError**
+
+## Index
+
+### Properties
+
+* [at](_decoder_.decodererror.md#at)
+* [input](_decoder_.decodererror.md#input)
+* [kind](_decoder_.decodererror.md#kind)
+* [message](_decoder_.decodererror.md#message)
+
+---
 
 ## Properties
+
 <a id="at"></a>
 
 ###  at
 
-**●  at**:  *`string`* 
-
-
-
-
-
+**● at**: *`string`*
 
 ___
-
 <a id="input"></a>
 
 ###  input
 
-**●  input**:  *`any`* 
-
-
-
-
-
+**● input**: *`any`*
 
 ___
-
 <a id="kind"></a>
 
 ###  kind
 
-**●  kind**:  *"DecoderError"* 
-
-
-
-
-
+**● kind**: *"DecoderError"*
 
 ___
-
 <a id="message"></a>
 
 ###  message
 
-**●  message**:  *`string`* 
-
-
-
-
-
+**● message**: *`string`*
 
 ___
-
 

--- a/docs/interfaces/_result_.err.md
+++ b/docs/interfaces/_result_.err.md
@@ -1,40 +1,38 @@
 [@mojotech/json-type-validation](../README.md) > ["result"](../modules/_result_.md) > [Err](../interfaces/_result_.err.md)
 
-
-
 # Interface: Err
-
 
 The error type variant for `Result`. Denotes that some error occurred before the result was computed.
 
 ## Type parameters
 #### E 
+## Hierarchy
+
+**Err**
+
+## Index
+
+### Properties
+
+* [error](_result_.err.md#error)
+* [ok](_result_.err.md#ok)
+
+---
 
 ## Properties
+
 <a id="error"></a>
 
 ###  error
 
-**●  error**:  *`E`* 
-
-
-
-
-
+**● error**: *`E`*
 
 ___
-
 <a id="ok"></a>
 
 ###  ok
 
-**●  ok**:  *`false`* 
-
-
-
-
-
+**● ok**: *`false`*
 
 ___
-
 

--- a/docs/interfaces/_result_.ok.md
+++ b/docs/interfaces/_result_.ok.md
@@ -1,40 +1,38 @@
 [@mojotech/json-type-validation](../README.md) > ["result"](../modules/_result_.md) > [Ok](../interfaces/_result_.ok.md)
 
-
-
 # Interface: Ok
-
 
 The success type variant for `Result`. Denotes that a result value was computed with no errors.
 
 ## Type parameters
 #### V 
+## Hierarchy
+
+**Ok**
+
+## Index
+
+### Properties
+
+* [ok](_result_.ok.md#ok)
+* [result](_result_.ok.md#result)
+
+---
 
 ## Properties
+
 <a id="ok"></a>
 
 ###  ok
 
-**●  ok**:  *`true`* 
-
-
-
-
-
+**● ok**: *`true`*
 
 ___
-
 <a id="result"></a>
 
 ###  result
 
-**●  result**:  *`V`* 
-
-
-
-
-
+**● result**: *`V`*
 
 ___
-
 

--- a/docs/modules/_combinators_.md
+++ b/docs/modules/_combinators_.md
@@ -1,7 +1,5 @@
 [@mojotech/json-type-validation](../README.md) > ["combinators"](../modules/_combinators_.md)
 
-
-
 # External module: "combinators"
 
 ## Index
@@ -19,7 +17,6 @@
 * [valueAt](_combinators_.md#valueat)
 * [withDefault](_combinators_.md#withdefault)
 
-
 ### Functions
 
 * [boolean](_combinators_.md#boolean)
@@ -29,590 +26,350 @@
 * [string](_combinators_.md#string)
 * [union](_combinators_.md#union)
 
-
-
 ---
+
 ## Variables
+
 <a id="anyjson"></a>
 
-###  anyJson
+### `<Const>` anyJson
 
-**●  anyJson**:  *`function`*  =  Decoder.anyJson
-
-
-
+**● anyJson**: *`function`* =  Decoder.anyJson
 
 See `Decoder.anyJson`
 
 #### Type declaration
-►(): [Decoder](../classes/_decoder_.decoder.md)`any`
+▸(): [Decoder](../classes/_decoder_.decoder.md)<`any`>
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`any`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`any`>
 
 ___
-
 <a id="array"></a>
 
-###  array
+### `<Const>` array
 
-**●  array**:  *`function`*  =  Decoder.array
-
-
-
+**● array**: *`function`* =  Decoder.array
 
 See `Decoder.array`
 
 #### Type declaration
-►A(decoder: *[Decoder](../classes/_decoder_.decoder.md)`A`*): [Decoder](../classes/_decoder_.decoder.md)`A`[]
-
-
+▸A(decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`[]>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`[]
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`[]>
 
 ___
-
 <a id="dict"></a>
 
-###  dict
+### `<Const>` dict
 
-**●  dict**:  *`function`*  =  Decoder.dict
-
-
-
+**● dict**: *`function`* =  Decoder.dict
 
 See `Decoder.dict`
 
 #### Type declaration
-►A(decoder: *[Decoder](../classes/_decoder_.decoder.md)`A`*): [Decoder](../classes/_decoder_.decoder.md)`object`
-
-
+▸A(decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`object`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`object`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`object`>
 
 ___
-
 <a id="fail"></a>
 
-###  fail
+### `<Const>` fail
 
-**●  fail**:  *`function`*  =  Decoder.fail
-
-
-
+**● fail**: *`function`* =  Decoder.fail
 
 See `Decoder.fail`
 
 #### Type declaration
-►A(errorMessage: *`string`*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
+▸A(errorMessage: *`string`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| errorMessage | `string`   |  - |
+| Param | Type |
+| ------ | ------ |
+| errorMessage | `string` |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="lazy"></a>
 
-###  lazy
+### `<Const>` lazy
 
-**●  lazy**:  *`function`*  =  Decoder.lazy
-
-
-
+**● lazy**: *`function`* =  Decoder.lazy
 
 See `Decoder.lazy`
 
 #### Type declaration
-►A(mkDecoder: *`function`*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
+▸A(mkDecoder: *`function`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| mkDecoder | `function`   |  - |
+| Param | Type |
+| ------ | ------ |
+| mkDecoder | `function` |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="oneof"></a>
 
-###  oneOf
+### `<Const>` oneOf
 
-**●  oneOf**:  *`function`*  =  Decoder.oneOf
-
-
-
+**● oneOf**: *`function`* =  Decoder.oneOf
 
 See `Decoder.oneOf`
 
 #### Type declaration
-►A(...decoders: *[Decoder](../classes/_decoder_.decoder.md)`A`[]*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
+▸A(...decoders: *[Decoder](../classes/_decoder_.decoder.md)<`A`>[]*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoders | [Decoder](../classes/_decoder_.decoder.md)`A`[]   |  - |
+| Param | Type |
+| ------ | ------ |
+| `Rest` decoders | [Decoder](../classes/_decoder_.decoder.md)<`A`>[] |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="optional"></a>
 
-###  optional
+### `<Const>` optional
 
-**●  optional**:  *`function`*  =  Decoder.optional
-
-
-
+**● optional**: *`function`* =  Decoder.optional
 
 See `Decoder.optional`
 
 #### Type declaration
-►A(decoder: *[Decoder](../classes/_decoder_.decoder.md)`A`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`undefined`
-
-
+▸A(decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `undefined`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`undefined`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `undefined`>
 
 ___
-
 <a id="succeed"></a>
 
-###  succeed
+### `<Const>` succeed
 
-**●  succeed**:  *`function`*  =  Decoder.succeed
-
-
-
+**● succeed**: *`function`* =  Decoder.succeed
 
 See `Decoder.succeed`
 
 #### Type declaration
-►A(fixedValue: *`A`*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
+▸A(fixedValue: *`A`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| fixedValue | `A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| fixedValue | `A` |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="valueat"></a>
 
-###  valueAt
+### `<Const>` valueAt
 
-**●  valueAt**:  *`function`*  = 
+**● valueAt**: *`function`* = 
   Decoder.valueAt
-
-
-
 
 See `Decoder.valueAt`
 
 #### Type declaration
-►A(paths: *(`string`⎮`number`)[]*, decoder: *[Decoder](../classes/_decoder_.decoder.md)`A`*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
+▸A(paths: *( `string` &#124; `number`)[]*, decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| paths | (`string`⎮`number`)[]   |  - |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| paths | ( `string` &#124; `number`)[] |
+| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="withdefault"></a>
 
-###  withDefault
+### `<Const>` withDefault
 
-**●  withDefault**:  *`function`*  = 
+**● withDefault**: *`function`* = 
   Decoder.withDefault
-
-
-
 
 See `Decoder.withDefault`
 
 #### Type declaration
-►A(defaultValue: *`A`*, decoder: *[Decoder](../classes/_decoder_.decoder.md)`A`*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
+▸A(defaultValue: *`A`*, decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| defaultValue | `A`   |  - |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| defaultValue | `A` |
+| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
 
-
 ## Functions
+
 <a id="boolean"></a>
 
 ###  boolean
 
-► **boolean**(): [Decoder](../classes/_decoder_.decoder.md)`boolean`
-
-
-
-
-
+▸ **boolean**(): [Decoder](../classes/_decoder_.decoder.md)<`boolean`>
 
 See `Decoder.boolean`
 
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`boolean`
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`boolean`>
 
 ___
-
 <a id="constant"></a>
 
 ###  constant
 
-► **constant**(value: *`true`*): [Decoder](../classes/_decoder_.decoder.md)`true`
+▸ **constant**(value: *`true`*): [Decoder](../classes/_decoder_.decoder.md)<`true`>
 
-► **constant**(value: *`false`*): [Decoder](../classes/_decoder_.decoder.md)`false`
+▸ **constant**(value: *`false`*): [Decoder](../classes/_decoder_.decoder.md)<`false`>
 
-► **constant**A(value: *`A`*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **constant**A(value: *`A`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 See `Decoder.constant`
 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| value | `true` |
+
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`true`>
 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| value | `true`   |  - |
+| Param | Type |
+| ------ | ------ |
+| value | `false` |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`true`
-
-
-
-
-
-
-**Parameters:**
-
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| value | `false`   |  - |
-
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`false`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`false`>
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| value | `A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| value | `A` |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="number"></a>
 
 ###  number
 
-► **number**(): [Decoder](../classes/_decoder_.decoder.md)`number`
-
-
-
-
-
+▸ **number**(): [Decoder](../classes/_decoder_.decoder.md)<`number`>
 
 See `Decoder.number`
 
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`number`
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`number`>
 
 ___
-
 <a id="object"></a>
 
 ###  object
 
-► **object**A(decoders: *[DecoderObject](_decoder_.md#decoderobject)`A`*): [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
-
+▸ **object**A(decoders: *[DecoderObject](_decoder_.md#decoderobject)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 See `Decoder.object`
-
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| decoders | [DecoderObject](_decoder_.md#decoderobject)`A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| decoders | [DecoderObject](_decoder_.md#decoderobject)<`A`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
-
 <a id="string"></a>
 
 ###  string
 
-► **string**(): [Decoder](../classes/_decoder_.decoder.md)`string`
-
-
-
-
-
+▸ **string**(): [Decoder](../classes/_decoder_.decoder.md)<`string`>
 
 See `Decoder.string`
 
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`string`
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`string`>
 
 ___
-
 <a id="union"></a>
 
 ###  union
 
-► **union**A,B(ad: *[Decoder](../classes/_decoder_.decoder.md)`A`*, bd: *[Decoder](../classes/_decoder_.decoder.md)`B`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`
+▸ **union**A,B(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B`>
 
-► **union**A,B,C(ad: *[Decoder](../classes/_decoder_.decoder.md)`A`*, bd: *[Decoder](../classes/_decoder_.decoder.md)`B`*, cd: *[Decoder](../classes/_decoder_.decoder.md)`C`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`
+▸ **union**A,B,C(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C`>
 
-► **union**A,B,C,D(ad: *[Decoder](../classes/_decoder_.decoder.md)`A`*, bd: *[Decoder](../classes/_decoder_.decoder.md)`B`*, cd: *[Decoder](../classes/_decoder_.decoder.md)`C`*, dd: *[Decoder](../classes/_decoder_.decoder.md)`D`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`
+▸ **union**A,B,C,D(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D`>
 
-► **union**A,B,C,D,E(ad: *[Decoder](../classes/_decoder_.decoder.md)`A`*, bd: *[Decoder](../classes/_decoder_.decoder.md)`B`*, cd: *[Decoder](../classes/_decoder_.decoder.md)`C`*, dd: *[Decoder](../classes/_decoder_.decoder.md)`D`*, ed: *[Decoder](../classes/_decoder_.decoder.md)`E`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`
+▸ **union**A,B,C,D,E(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E`>
 
-► **union**A,B,C,D,E,F(ad: *[Decoder](../classes/_decoder_.decoder.md)`A`*, bd: *[Decoder](../classes/_decoder_.decoder.md)`B`*, cd: *[Decoder](../classes/_decoder_.decoder.md)`C`*, dd: *[Decoder](../classes/_decoder_.decoder.md)`D`*, ed: *[Decoder](../classes/_decoder_.decoder.md)`E`*, fd: *[Decoder](../classes/_decoder_.decoder.md)`F`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`
+▸ **union**A,B,C,D,E,F(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*, fd: *[Decoder](../classes/_decoder_.decoder.md)<`F`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F`>
 
-► **union**A,B,C,D,E,F,G(ad: *[Decoder](../classes/_decoder_.decoder.md)`A`*, bd: *[Decoder](../classes/_decoder_.decoder.md)`B`*, cd: *[Decoder](../classes/_decoder_.decoder.md)`C`*, dd: *[Decoder](../classes/_decoder_.decoder.md)`D`*, ed: *[Decoder](../classes/_decoder_.decoder.md)`E`*, fd: *[Decoder](../classes/_decoder_.decoder.md)`F`*, gd: *[Decoder](../classes/_decoder_.decoder.md)`G`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`
+▸ **union**A,B,C,D,E,F,G(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*, fd: *[Decoder](../classes/_decoder_.decoder.md)<`F`>*, gd: *[Decoder](../classes/_decoder_.decoder.md)<`G`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G`>
 
-► **union**A,B,C,D,E,F,G,H(ad: *[Decoder](../classes/_decoder_.decoder.md)`A`*, bd: *[Decoder](../classes/_decoder_.decoder.md)`B`*, cd: *[Decoder](../classes/_decoder_.decoder.md)`C`*, dd: *[Decoder](../classes/_decoder_.decoder.md)`D`*, ed: *[Decoder](../classes/_decoder_.decoder.md)`E`*, fd: *[Decoder](../classes/_decoder_.decoder.md)`F`*, gd: *[Decoder](../classes/_decoder_.decoder.md)`G`*, hd: *[Decoder](../classes/_decoder_.decoder.md)`H`*): [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`⎮`H`
-
-
-
-
-
+▸ **union**A,B,C,D,E,F,G,H(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*, fd: *[Decoder](../classes/_decoder_.decoder.md)<`F`>*, gd: *[Decoder](../classes/_decoder_.decoder.md)<`G`>*, hd: *[Decoder](../classes/_decoder_.decoder.md)<`H`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G` &#124; `H`>
 
 See `Decoder.union`
-
 
 **Type parameters:**
 
@@ -620,21 +377,12 @@ See `Decoder.union`
 #### B 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](../classes/_decoder_.decoder.md)`B`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B`>
 
 **Type parameters:**
 
@@ -643,22 +391,13 @@ See `Decoder.union`
 #### C 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](../classes/_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](../classes/_decoder_.decoder.md)`C`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C`>
 
 **Type parameters:**
 
@@ -668,23 +407,14 @@ See `Decoder.union`
 #### D 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](../classes/_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](../classes/_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](../classes/_decoder_.decoder.md)`D`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D`>
 
 **Type parameters:**
 
@@ -695,24 +425,15 @@ See `Decoder.union`
 #### E 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](../classes/_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](../classes/_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](../classes/_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](../classes/_decoder_.decoder.md)`E`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E`>
 
 **Type parameters:**
 
@@ -724,25 +445,16 @@ See `Decoder.union`
 #### F 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](../classes/_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](../classes/_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](../classes/_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](../classes/_decoder_.decoder.md)`E`   |  - |
-| fd | [Decoder](../classes/_decoder_.decoder.md)`F`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](../classes/_decoder_.decoder.md)<`F`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F`>
 
 **Type parameters:**
 
@@ -755,26 +467,17 @@ See `Decoder.union`
 #### G 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](../classes/_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](../classes/_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](../classes/_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](../classes/_decoder_.decoder.md)`E`   |  - |
-| fd | [Decoder](../classes/_decoder_.decoder.md)`F`   |  - |
-| gd | [Decoder](../classes/_decoder_.decoder.md)`G`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](../classes/_decoder_.decoder.md)<`F`> |
+| gd | [Decoder](../classes/_decoder_.decoder.md)<`G`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`
-
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G`>
 
 **Type parameters:**
 
@@ -788,27 +491,18 @@ See `Decoder.union`
 #### H 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)`A`   |  - |
-| bd | [Decoder](../classes/_decoder_.decoder.md)`B`   |  - |
-| cd | [Decoder](../classes/_decoder_.decoder.md)`C`   |  - |
-| dd | [Decoder](../classes/_decoder_.decoder.md)`D`   |  - |
-| ed | [Decoder](../classes/_decoder_.decoder.md)`E`   |  - |
-| fd | [Decoder](../classes/_decoder_.decoder.md)`F`   |  - |
-| gd | [Decoder](../classes/_decoder_.decoder.md)`G`   |  - |
-| hd | [Decoder](../classes/_decoder_.decoder.md)`H`   |  - |
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](../classes/_decoder_.decoder.md)<`F`> |
+| gd | [Decoder](../classes/_decoder_.decoder.md)<`G`> |
+| hd | [Decoder](../classes/_decoder_.decoder.md)<`H`> |
 
-
-
-
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)`A`⎮`B`⎮`C`⎮`D`⎮`E`⎮`F`⎮`G`⎮`H`
-
-
-
-
+**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G` &#124; `H`>
 
 ___
-
 

--- a/docs/modules/_decoder_.md
+++ b/docs/modules/_decoder_.md
@@ -1,7 +1,5 @@
 [@mojotech/json-type-validation](../README.md) > ["decoder"](../modules/_decoder_.md)
 
-
-
 # External module: "decoder"
 
 ## Index
@@ -10,121 +8,83 @@
 
 * [Decoder](../classes/_decoder_.decoder.md)
 
-
 ### Interfaces
 
 * [DecoderError](../interfaces/_decoder_.decodererror.md)
 
-
 ### Type aliases
 
 * [DecoderObject](_decoder_.md#decoderobject)
-
 
 ### Functions
 
 * [decoderErrorString](_decoder_.md#decodererrorstring)
 * [isDecoderError](_decoder_.md#isdecodererror)
 
-
-
 ---
+
 ## Type aliases
+
 <a id="decoderobject"></a>
 
 ###  DecoderObject
 
-**Τ DecoderObject**:  *`object`* 
-
-
-
+**ΤDecoderObject**: *`object`*
 
 Defines a mapped type over an interface `A`. `DecoderObject<A>` is an interface that has all the keys or `A`, but each key's property type is mapped to a decoder for that type. This type is used when creating decoders for objects.
 
 Example:
 
-    interface X {
-      a: boolean;
-      b: string;
-    }
+```
+interface X {
+  a: boolean;
+  b: string;
+}
 
-    const decoderObject: DecoderObject<X> = {
-      a: boolean(),
-      b: string()
-    }
+const decoderObject: DecoderObject<X> = {
+  a: boolean(),
+  b: string()
+}
+```
 
 #### Type declaration
 
-
-
-
-
 ___
 
-
 ## Functions
+
 <a id="decodererrorstring"></a>
 
-###  decoderErrorString
+### `<Const>` decoderErrorString
 
-► **decoderErrorString**(error: *[DecoderError](../interfaces/_decoder_.decodererror.md)*): `string`
-
-
-
-
-
+▸ **decoderErrorString**(error: *[DecoderError](../interfaces/_decoder_.decodererror.md)*): `string`
 
 `DecoderError` information as a formatted string.
 
-
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| error | [DecoderError](../interfaces/_decoder_.decodererror.md)   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| error | [DecoderError](../interfaces/_decoder_.decodererror.md) |
 
 **Returns:** `string`
 
-
-
-
-
 ___
-
 <a id="isdecodererror"></a>
 
-###  isDecoderError
+### `<Const>` isDecoderError
 
-► **isDecoderError**(a: *`any`*): `boolean`
-
-
-
-
-
+▸ **isDecoderError**(a: *`any`*): `boolean`
 
 Type guard for `DecoderError`. One use case of the type guard is in the `catch` of a promise. Typescript types the error argument of `catch` as `any`, so when dealing with a decoder as a promise you may need to distinguish between a `DecoderError` and an error string.
 
-
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| a | `any`   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| a | `any` |
 
 **Returns:** `boolean`
 
-
-
-
-
 ___
-
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -1,10 +1,8 @@
 [@mojotech/json-type-validation](../README.md) > ["index"](../modules/_index_.md)
 
-
-
 # External module: "index"
 
 ## Index
 
-
 ---
+

--- a/docs/modules/_result_.md
+++ b/docs/modules/_result_.md
@@ -1,7 +1,5 @@
 [@mojotech/json-type-validation](../README.md) > ["result"](../modules/_result_.md)
 
-
-
 # External module: "result"
 
 ## Index
@@ -11,11 +9,9 @@
 * [Err](../interfaces/_result_.err.md)
 * [Ok](../interfaces/_result_.ok.md)
 
-
 ### Type aliases
 
 * [Result](_result_.md#result)
-
 
 ### Functions
 
@@ -31,41 +27,30 @@
 * [withDefault](_result_.md#withdefault)
 * [withException](_result_.md#withexception)
 
-
-
 ---
+
 ## Type aliases
+
 <a id="result"></a>
 
 ###  Result
 
-**Τ Result**:  *[Ok](../interfaces/_result_.ok.md)`V`⎮[Err](../interfaces/_result_.err.md)`E`* 
-
-
-
+**ΤResult**: * [Ok](../interfaces/_result_.ok.md)<`V`> &#124; [Err](../interfaces/_result_.err.md)<`E`>
+*
 
 The result of a computation that may fail. The decoding function `Decoder.run` returns a `Result`. The value of a `Result` is either `Ok` if the computation succeeded, or `Err` if there was some failure in the process.
 
-
-
-
 ___
 
-
 ## Functions
+
 <a id="andthen"></a>
 
-###  andThen
+### `<Const>` andThen
 
-► **andThen**A,B,E(f: *`function`*, r: *[Result](_result_.md#result)`A`, `E`*): [Result](_result_.md#result)`B`, `E`
-
-
-
-
-
+▸ **andThen**A,B,E(f: *`function`*, r: *[Result](_result_.md#result)<`A`, `E`>*): [Result](_result_.md#result)<`B`, `E`>
 
 Chain together a sequence of computations that may fail, similar to a `Promise`. If the first computation fails then the error will propagate through. If it succeeds, then `f` will be applied to the value, returning a new `Result`.
-
 
 **Type parameters:**
 
@@ -74,178 +59,103 @@ Chain together a sequence of computations that may fail, similar to a `Promise`.
 #### E 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| f | `function`   |  - |
-| r | [Result](_result_.md#result)`A`, `E`   |  - |
+| Param | Type |
+| ------ | ------ |
+| f | `function` |
+| r | [Result](_result_.md#result)<`A`, `E`> |
 
-
-
-
-
-**Returns:** [Result](_result_.md#result)`B`, `E`
-
-
-
-
+**Returns:** [Result](_result_.md#result)<`B`, `E`>
 
 ___
-
 <a id="aspromise"></a>
 
-###  asPromise
+### `<Const>` asPromise
 
-► **asPromise**V(r: *[Result](_result_.md#result)`V`, `any`*): `Promise`.<`V`>
-
-
-
-
-
+▸ **asPromise**V(r: *[Result](_result_.md#result)<`V`, `any`>*): `Promise`<`V`>
 
 Create a `Promise` that either resolves with the result of `Ok` or rejects with the error of `Err`.
-
 
 **Type parameters:**
 
 #### V 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| r | [Result](_result_.md#result)`V`, `any`   |  - |
+| Param | Type |
+| ------ | ------ |
+| r | [Result](_result_.md#result)<`V`, `any`> |
 
-
-
-
-
-**Returns:** `Promise`.<`V`>
-
-
-
-
+**Returns:** `Promise`<`V`>
 
 ___
-
 <a id="err-1"></a>
 
-###  err
+### `<Const>` err
 
-► **err**E(error: *`E`*): [Err](../interfaces/_result_.err.md)`E`
-
-
-
-
-
+▸ **err**E(error: *`E`*): [Err](../interfaces/_result_.err.md)<`E`>
 
 Wraps errors in an `Err` type.
 
 Example: `err('on fire') // => {ok: false, error: 'on fire'}`
 
-
 **Type parameters:**
 
 #### E 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| error | `E`   |  - |
+| Param | Type |
+| ------ | ------ |
+| error | `E` |
 
-
-
-
-
-**Returns:** [Err](../interfaces/_result_.err.md)`E`
-
-
-
-
+**Returns:** [Err](../interfaces/_result_.err.md)<`E`>
 
 ___
-
 <a id="iserr"></a>
 
-###  isErr
+### `<Const>` isErr
 
-► **isErr**E(r: *[Result](_result_.md#result)`any`, `E`*): `boolean`
-
-
-
-
-
+▸ **isErr**E(r: *[Result](_result_.md#result)<`any`, `E`>*): `boolean`
 
 Typeguard for `Err`.
 
-
 **Type parameters:**
 
 #### E 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| r | [Result](_result_.md#result)`any`, `E`   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| r | [Result](_result_.md#result)<`any`, `E`> |
 
 **Returns:** `boolean`
 
-
-
-
-
 ___
-
 <a id="isok"></a>
 
-###  isOk
+### `<Const>` isOk
 
-► **isOk**V(r: *[Result](_result_.md#result)`V`, `any`*): `boolean`
-
-
-
-
-
+▸ **isOk**V(r: *[Result](_result_.md#result)<`V`, `any`>*): `boolean`
 
 Typeguard for `Ok`.
 
-
 **Type parameters:**
 
 #### V 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| r | [Result](_result_.md#result)`V`, `any`   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| r | [Result](_result_.md#result)<`V`, `any`> |
 
 **Returns:** `boolean`
 
-
-
-
-
 ___
-
 <a id="map"></a>
 
-###  map
+### `<Const>` map
 
-► **map**A,B,E(f: *`function`*, r: *[Result](_result_.md#result)`A`, `E`*): [Result](_result_.md#result)`B`, `E`
-
-
-
-
-
+▸ **map**A,B,E(f: *`function`*, r: *[Result](_result_.md#result)<`A`, `E`>*): [Result](_result_.md#result)<`B`, `E`>
 
 Apply `f` to the result of an `Ok`, or pass the error through.
-
 
 **Type parameters:**
 
@@ -254,36 +164,21 @@ Apply `f` to the result of an `Ok`, or pass the error through.
 #### E 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| f | `function`   |  - |
-| r | [Result](_result_.md#result)`A`, `E`   |  - |
+| Param | Type |
+| ------ | ------ |
+| f | `function` |
+| r | [Result](_result_.md#result)<`A`, `E`> |
 
-
-
-
-
-**Returns:** [Result](_result_.md#result)`B`, `E`
-
-
-
-
+**Returns:** [Result](_result_.md#result)<`B`, `E`>
 
 ___
-
 <a id="maperror"></a>
 
-###  mapError
+### `<Const>` mapError
 
-► **mapError**V,A,B(f: *`function`*, r: *[Result](_result_.md#result)`V`, `A`*): [Result](_result_.md#result)`V`, `B`
-
-
-
-
-
+▸ **mapError**V,A,B(f: *`function`*, r: *[Result](_result_.md#result)<`V`, `A`>*): [Result](_result_.md#result)<`V`, `B`>
 
 Apply `f` to the error of an `Err`, or pass the success through.
-
 
 **Type parameters:**
 
@@ -292,179 +187,114 @@ Apply `f` to the error of an `Err`, or pass the success through.
 #### B 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| f | `function`   |  - |
-| r | [Result](_result_.md#result)`V`, `A`   |  - |
+| Param | Type |
+| ------ | ------ |
+| f | `function` |
+| r | [Result](_result_.md#result)<`V`, `A`> |
 
-
-
-
-
-**Returns:** [Result](_result_.md#result)`V`, `B`
-
-
-
-
+**Returns:** [Result](_result_.md#result)<`V`, `B`>
 
 ___
-
 <a id="ok-1"></a>
 
-###  ok
+### `<Const>` ok
 
-► **ok**V(result: *`V`*): [Ok](../interfaces/_result_.ok.md)`V`
-
-
-
-
-
+▸ **ok**V(result: *`V`*): [Ok](../interfaces/_result_.ok.md)<`V`>
 
 Wraps values in an `Ok` type.
 
 Example: `ok(5) // => {ok: true, result: 5}`
 
-
 **Type parameters:**
 
 #### V 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| result | `V`   |  - |
+| Param | Type |
+| ------ | ------ |
+| result | `V` |
 
-
-
-
-
-**Returns:** [Ok](../interfaces/_result_.ok.md)`V`
-
-
-
-
+**Returns:** [Ok](../interfaces/_result_.ok.md)<`V`>
 
 ___
-
 <a id="successes"></a>
 
-###  successes
+### `<Const>` successes
 
-► **successes**A(results: *[Result](_result_.md#result)`A`, `any`[]*): `A`[]
-
-
-
-
-
+▸ **successes**A(results: *[Result](_result_.md#result)<`A`, `any`>[]*): `A`[]
 
 Given an array of `Result`s, return the successful values.
-
 
 **Type parameters:**
 
 #### A 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| results | [Result](_result_.md#result)`A`, `any`[]   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| results | [Result](_result_.md#result)<`A`, `any`>[] |
 
 **Returns:** `A`[]
 
-
-
-
-
 ___
-
 <a id="withdefault"></a>
 
-###  withDefault
+### `<Const>` withDefault
 
-► **withDefault**V(defaultValue: *`V`*, r: *[Result](_result_.md#result)`V`, `any`*): `V`
-
-
-
-
-
+▸ **withDefault**V(defaultValue: *`V`*, r: *[Result](_result_.md#result)<`V`, `any`>*): `V`
 
 Unwraps a `Result` and returns either the result of an `Ok`, or `defaultValue`.
 
 Example:
 
-    Result.withDefault(5, number().run(json))
+```
+Result.withDefault(5, number().run(json))
+```
 
 It would be nice if `Decoder` had an instance method that mirrored this function. Such a method would look something like this:
 
-    class Decoder<A> {
-      runWithDefault = (defaultValue: A, json: any): A =>
-        Result.withDefault(defaultValue, this.run(json));
-    }
+```
+class Decoder<A> {
+  runWithDefault = (defaultValue: A, json: any): A =>
+    Result.withDefault(defaultValue, this.run(json));
+}
 
-    number().runWithDefault(5, json)
+number().runWithDefault(5, json)
+```
 
 Unfortunately, the type of `defaultValue: A` on the method causes issues with type inference on the `object` decoder in some situations. While these inference issues can be solved by providing the optional type argument for `object`s, the extra trouble and confusion doesn't seem worth it.
 
-
 **Type parameters:**
 
 #### V 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| defaultValue | `V`   |  - |
-| r | [Result](_result_.md#result)`V`, `any`   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| defaultValue | `V` |
+| r | [Result](_result_.md#result)<`V`, `any`> |
 
 **Returns:** `V`
 
-
-
-
-
 ___
-
 <a id="withexception"></a>
 
-###  withException
+### `<Const>` withException
 
-► **withException**V(r: *[Result](_result_.md#result)`V`, `any`*): `V`
-
-
-
-
-
+▸ **withException**V(r: *[Result](_result_.md#result)<`V`, `any`>*): `V`
 
 Return the successful result, or throw an error.
 
-
 **Type parameters:**
 
 #### V 
 **Parameters:**
 
-| Param | Type | Description |
-| ------ | ------ | ------ |
-| r | [Result](_result_.md#result)`V`, `any`   |  - |
-
-
-
-
+| Param | Type |
+| ------ | ------ |
+| r | [Result](_result_.md#result)<`V`, `any`> |
 
 **Returns:** `V`
 
-
-
-
-
 ___
-
 

--- a/package.json
+++ b/package.json
@@ -62,8 +62,9 @@
     "mapCoverage": true
   },
   "devDependencies": {
-    "@types/jest": "^22.0.0",
-    "@types/node": "^8.0.0",
+    "@types/jest": "^22.2.3",
+    "@types/lodash": "^4.14.0",
+    "@types/node": "^10.5.3",
     "colors": "^1.1.2",
     "cross-env": "^5.0.1",
     "jest": "^22.0.2",
@@ -80,8 +81,8 @@
     "tslint": "^5.8.0",
     "tslint-config-prettier": "^1.1.0",
     "tslint-config-standard": "^7.0.0",
-    "typedoc": "^0.9.0",
-    "typedoc-plugin-markdown": "^1.0.12",
-    "typescript": "~2.6.2"
+    "typedoc": "^0.11.1",
+    "typedoc-plugin-markdown": "^1.0.13",
+    "typescript": "~2.9.2"
   }
 }

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -112,6 +112,20 @@ const prependAt = (newAt: string, {at, ...rest}: Partial<DecoderError>): Partial
  * things with a `Result` as with the decoder methods.
  */
 export class Decoder<A> {
+  /**
+   * The Decoder class constructor is kept private to separate the internal
+   * `decode` function from the external `run` function. The distinction
+   * between the two functions is that `decode` returns a
+   * `Partial<DecoderError>` on failure, which contains an unfinished error
+   * report. When `run` is called on a decoder, the relevant series of `decode`
+   * calls is made, and then on failure the resulting `Partial<DecoderError>`
+   * is turned into a `DecoderError` by filling in the missing informaiton.
+   *
+   * While hiding the constructor may seem restrictive, leveraging the
+   * provided decoder combinators and helper functions such as
+   * `andThen` and `map` should be enough to build specialized decoders as
+   * needed.
+   */
   private constructor(private decode: (json: any) => Result.Result<A, Partial<DecoderError>>) {}
 
   /**

--- a/test/json-decode.test.ts
+++ b/test/json-decode.test.ts
@@ -243,28 +243,6 @@ describe('object', () => {
     });
   });
 
-  it('ignores inharited fields in the decoder object', () => {
-    function decoderObject() {
-      return;
-    }
-
-    decoderObject.prototype.addedField = number();
-
-    // this line raises the typescript error TS7009, because `new` should only
-    // be used on classes.
-    let decoderFields = new decoderObject();
-    decoderFields.a = boolean();
-    decoderFields.b = string();
-
-    const decoder = object(decoderFields);
-
-    expect(decoderFields.addedField).toBeDefined();
-    expect(decoder.run({a: true, b: 'hats', addedField: 5})).toEqual({
-      ok: true,
-      result: {a: true, b: 'hats'}
-    });
-  });
-
   it('ignores optional fields that decode to undefined', () => {
     const decoder = object({
       a: number(),
@@ -351,27 +329,6 @@ describe('dict', () => {
         ok: true,
         result: {hey: 'there!', yo: 'dude!'}
       });
-    });
-  });
-
-  describe('ignores inharited fields in the json object', () => {
-    it('', () => {
-      function jsonObject() {
-        return;
-      }
-
-      jsonObject.prototype.addedField = 3;
-
-      // this line raises the typescript error TS7009, because `new` should
-      // only be used on classes.
-      let json = new jsonObject();
-      json.a = 1;
-      json.b = 2;
-
-      const decoder = dict(number());
-
-      expect(json.addedField).toBe(3);
-      expect(decoder.run(json)).toEqual({ok: true, result: {a: 1, b: 2}});
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,55 +3,80 @@
 
 
 "@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.39"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.39.tgz#91c90bb65207fc5a55128cb54956ded39e850457"
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.54.tgz#0024f96fdf7028a21d68e273afd4e953214a1ead"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.54"
+
+"@babel/highlight@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.54.tgz#155d507358329b8e7068970017c3fd74a9b08584"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@types/fs-extra@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
+"@forked/turndown@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@forked/turndown/-/turndown-4.0.4.tgz#26d0a26ad6bcdfd467b33aa83e8c81c8d39d5a43"
+  dependencies:
+    jsdom "^11.10.0"
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+
+"@types/fs-extra@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.1.tgz#cd856fbbdd6af2c11f26f8928fd8644c9e9616c9"
   dependencies:
     "@types/node" "*"
 
-"@types/handlebars@4.0.31":
-  version "4.0.31"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.31.tgz#a7fba66fafe42713aee88eeca8db91192efe6e72"
+"@types/glob@*":
+  version "5.0.35"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
 
-"@types/highlight.js@9.1.8":
-  version "9.1.8"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.8.tgz#d227f18bcb8f3f187e16965f2444859a04689758"
+"@types/handlebars@4.0.36":
+  version "4.0.36"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
 
-"@types/jest@^22.0.0":
-  version "22.1.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.1.1.tgz#231d7c60ed130200af9e96c82469ed25b59a7ea2"
+"@types/highlight.js@9.12.2":
+  version "9.12.2"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.2.tgz#6ee7cd395effe5ec80b515d3ff1699068cd0cd1d"
 
-"@types/lodash@4.14.74":
-  version "4.14.74"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
+"@types/jest@^22.2.3":
+  version "22.2.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
+
+"@types/lodash@4.14.104":
+  version "4.14.104"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.104.tgz#53ee2357fa2e6e68379341d92eb2ecea4b11bb80"
+
+"@types/lodash@^4.14.0":
+  version "4.14.114"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.114.tgz#e6f251af5994dd0d7ce141f9241439b4f40270f6"
 
 "@types/marked@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.3.0.tgz#583c223dd33385a1dda01aaf77b0cd0411c4b524"
 
-"@types/minimatch@2.0.29":
-  version "2.0.29"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
+"@types/minimatch@*", "@types/minimatch@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
-"@types/node@*":
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.0.tgz#b85a0bcf1e1cc84eb4901b7e96966aedc6f078d1"
+"@types/node@*", "@types/node@^10.5.3":
+  version "10.5.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.3.tgz#5bcfaf088ad17894232012877669634c06b20cc5"
 
-"@types/node@^8.0.0":
-  version "8.5.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.9.tgz#7155cfb4ae405bca4dd8df1a214c339e939109bf"
-
-"@types/shelljs@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.0.tgz#229c157c6bc1e67d6b990e6c5e18dbd2ff58cff0"
+"@types/shelljs@0.7.8":
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.8.tgz#4b4d6ee7926e58d7bca448a50ba442fd9f6715bd"
   dependencies:
+    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/strip-bom@^3.0.0":
@@ -62,7 +87,7 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
 
-abab@^1.0.3, abab@^1.0.4:
+abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
@@ -70,32 +95,15 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-acorn-globals@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
-  dependencies:
-    acorn "^4.0.4"
-
 acorn-globals@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
   dependencies:
     acorn "^5.0.0"
 
-acorn@^4.0.4:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
-
 acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
-
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 ajv@^5.1.0:
   version "5.5.2"
@@ -119,8 +127,8 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
 ansi-escapes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -134,9 +142,9 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0, ansi-styles@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
@@ -147,26 +155,33 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
-append-transform@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
   dependencies:
-    default-require-extensions "^1.0.0"
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
+
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  dependencies:
+    default-require-extensions "^2.0.0"
 
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
 are-we-there-yet@~1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d"
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -176,9 +191,17 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -200,6 +223,10 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -212,9 +239,9 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -233,30 +260,26 @@ async@^1.4.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.1.4:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
-    lodash "^4.14.0"
+    lodash "^4.17.10"
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-atob@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
-
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
+atob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.2.1, aws4@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+aws4@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -266,9 +289,9 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
+babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:
     babel-code-frame "^6.26.0"
     babel-generator "^6.26.0"
@@ -280,15 +303,15 @@ babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0:
     babel-traverse "^6.26.0"
     babel-types "^6.26.0"
     babylon "^6.18.0"
-    convert-source-map "^1.5.0"
-    debug "^2.6.8"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
     json5 "^0.5.1"
     lodash "^4.17.4"
     minimatch "^3.0.4"
     path-is-absolute "^1.0.1"
-    private "^0.1.7"
+    private "^0.1.8"
     slash "^1.0.0"
-    source-map "^0.5.6"
+    source-map "^0.5.7"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
@@ -310,12 +333,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.1.0.tgz#7fae6f655fffe77e818a8c2868c754a42463fdfd"
+babel-jest@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.4.tgz#977259240420e227444ebe49e226a61e49ea659d"
   dependencies:
     babel-plugin-istanbul "^4.1.5"
-    babel-preset-jest "^22.1.0"
+    babel-preset-jest "^22.4.4"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -323,25 +346,26 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-istanbul@^4.1.4, babel-plugin-istanbul@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
+babel-plugin-istanbul@^4.1.5, babel-plugin-istanbul@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
     find-up "^2.1.0"
-    istanbul-lib-instrument "^1.7.5"
-    test-exclude "^4.1.1"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
 
-babel-plugin-jest-hoist@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.1.0.tgz#c1281dd7887d77a1711dc760468c3b8285dde9ee"
+babel-plugin-jest-hoist@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz#b9851906eab34c7bf6f8c895a2b08bea1a844c0b"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
+babel-plugin-transform-es2015-modules-commonjs@^6.26.2:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
   dependencies:
     babel-plugin-transform-strict-mode "^6.24.1"
     babel-runtime "^6.26.0"
@@ -355,11 +379,11 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-preset-jest@^22.0.1, babel-preset-jest@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.1.0.tgz#ff4e704102f9642765e2254226050561d8942ec9"
+babel-preset-jest@^22.4.3, babel-preset-jest@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz#ec9fbd8bcd7dfd24b8b5320e0e688013235b7c39"
   dependencies:
-    babel-plugin-jest-hoist "^22.1.0"
+    babel-plugin-jest-hoist "^22.4.4"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:
@@ -422,9 +446,21 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
+
 bcrypt-pbkdf@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
   dependencies:
     tweetnacl "^0.14.3"
 
@@ -432,37 +468,9 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
-block-elements@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/block-elements/-/block-elements-1.2.0.tgz#8e04ccab638c7e2596f5065fb6c1c7518c905a5d"
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  dependencies:
-    inherits "~2.0.0"
-
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  dependencies:
-    hoek "2.x.x"
-
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
-
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -475,13 +483,28 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
 browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
 
 browser-resolve@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
   dependencies:
     resolve "1.1.7"
 
@@ -491,9 +514,31 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.0, builtin-modules@^1.1.1:
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+builtin-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -506,6 +551,12 @@ camelcase@^1.0.2:
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
+capture-exit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
+  dependencies:
+    rsvp "^3.3.3"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -529,12 +580,12 @@ chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
-    ansi-styles "^3.1.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
+    supports-color "^5.3.0"
 
 chokidar@^1.6.0:
   version "1.7.0"
@@ -551,9 +602,22 @@ chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
 ci-info@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -564,8 +628,8 @@ cliui@^2.1.0:
     wordwrap "0.0.2"
 
 cliui@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
@@ -579,36 +643,44 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-collapse-whitespace@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/collapse-whitespace/-/collapse-whitespace-1.1.2.tgz#b9b31d79d5594ee3c22c15819c54828e565b3085"
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
   dependencies:
-    block-elements "^1.0.0"
-    void-elements "^2.0.1"
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
 
 color-convert@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
   dependencies:
-    color-name "^1.1.1"
+    color-name "1.1.1"
 
-color-name@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
 colors@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.1.tgz#4accdb89cf2cabc7f982771925e9468784f32f3d"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
+combined-stream@1.0.6, combined-stream@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
 
 commander@^2.12.1:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.0.tgz#7b25325963e6aace20d3a9285b09379b0c2208b5"
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+
+compare-versions@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.0.tgz#af93ea705a96943f622ab309578b9b90586f39c3"
+
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -618,17 +690,17 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-content-type-parser@^1.0.1, content-type-parser@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
-
-convert-source-map@^1.4.0, convert-source-map@^1.5.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -651,13 +723,13 @@ cpx@^1.5.0:
     subarg "^1.0.0"
 
 cross-env@^5.0.1:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
   dependencies:
-    cross-spawn "^5.1.0"
+    cross-spawn "^6.0.5"
     is-windows "^1.0.0"
 
-cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -665,25 +737,23 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
-    boom "2.x.x"
-
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+"cssstyle@>= 0.3.1 < 0.4.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
   dependencies:
     cssom "0.3.x"
 
@@ -693,7 +763,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@^2.2.0, debug@^2.6.8:
+data-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.0.tgz#24802de4e81c298ea8a9388bb0d8e461c774684f"
+  dependencies:
+    abab "^1.0.4"
+    whatwg-mimetype "^2.0.0"
+    whatwg-url "^6.4.0"
+
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -713,19 +791,19 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
-deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-default-require-extensions@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
   dependencies:
-    strip-bom "^2.0.0"
+    strip-bom "^3.0.0"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -733,6 +811,25 @@ define-properties@^1.1.2:
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -757,10 +854,10 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
 diff@^3.1.0, diff@^3.2.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
-doctrine@^0.7.2:
+doctrine@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
   dependencies:
@@ -784,14 +881,14 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
 
 error-ex@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.5.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -811,36 +908,32 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.6.1, escodegen@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
+escodegen@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     optionator "^0.8.1"
   optionalDependencies:
-    source-map "~0.5.6"
+    source-map "~0.6.1"
 
 esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
 estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-estree-walker@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
-
-estree-walker@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.1.tgz#64fc375053abc6f57d73e9bd2f004644ad3c5854"
+estree-walker@^0.5.0, estree-walker@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
 
 esutils@^1.1.6:
   version "1.1.6"
@@ -851,10 +944,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
 exec-sh@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
   dependencies:
-    merge "^1.1.3"
+    merge "^1.2.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -878,32 +971,70 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
   dependencies:
     fill-range "^2.1.0"
 
-expect@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-22.1.0.tgz#f8f9b019ab275d859cbefed531fbaefe8972431d"
+expect@^22.4.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.3.tgz#d5a29d0a0e1fb2153557caef2674d4547e914674"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^22.1.0"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^22.1.0"
-    jest-message-util "^22.1.0"
-    jest-regex-util "^22.1.0"
+    jest-diff "^22.4.3"
+    jest-get-type "^22.4.3"
+    jest-matcher-utils "^22.4.3"
+    jest-message-util "^22.4.3"
+    jest-regex-util "^22.4.3"
 
-extend@~3.0.0, extend@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
+extend@~3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -914,8 +1045,8 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -943,14 +1074,23 @@ fileset@^2.0.2:
     minimatch "^3.0.3"
 
 fill-range@^2.1.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
   dependencies:
     is-number "^2.1.0"
     isobject "^2.0.0"
-    randomatic "^1.1.3"
+    randomatic "^3.0.0"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
+
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
 
 find-index@^0.1.1:
   version "0.1.1"
@@ -969,7 +1109,7 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -987,23 +1127,29 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
 form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.5"
+    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
-fs-extra@4.0.3, fs-extra@^4.0.0, fs-extra@^4.0.2:
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
+
+fs-extra@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.0.tgz#0f0afb290bb3deb87978da816fcd3c7797f3a817"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
@@ -1011,35 +1157,32 @@ fs-extra@4.0.3, fs-extra@^4.0.0, fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  dependencies:
+    minipass "^2.2.1"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0, fsevents@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
+fsevents@^1.0.0, fsevents@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.39"
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
 
-fstream-ignore@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
-  dependencies:
-    fstream "^1.0.0"
-    inherits "2"
-    minimatch "^3.0.0"
-
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
-
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -1057,12 +1200,16 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 get-caller-file@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
 
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -1122,20 +1269,9 @@ handlebars@^4.0.3, handlebars@^4.0.6:
   optionalDependencies:
     uglify-js "^2.6"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 har-validator@~5.0.3:
   version "5.0.3"
@@ -1154,49 +1290,50 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
 has@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
-    function-bind "^1.0.2"
-
-hawk@3.1.3, hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
+    function-bind "^1.1.1"
 
 highlight.js@^9.0.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-
-hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -1212,22 +1349,14 @@ homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
-html-encoding-sniffer@^1.0.1, html-encoding-sniffer@^1.0.2:
+html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -1240,6 +1369,18 @@ http-signature@~1.2.0:
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@^0.4.4:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  dependencies:
+    minimatch "^3.0.4"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -1259,7 +1400,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1272,14 +1413,26 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -1302,8 +1455,8 @@ is-builtin-module@^1.0.0:
     builtin-modules "^1.0.0"
 
 is-callable@^1.1.1, is-callable@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
 is-ci@^1.0.10:
   version "1.1.0"
@@ -1311,9 +1464,37 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.0.0"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -1325,9 +1506,15 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
@@ -1375,6 +1562,16 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -1405,9 +1602,9 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
+is-windows@^1.0.0, is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -1427,82 +1624,97 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 istanbul-api@^1.1.14:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
   dependencies:
     async "^2.1.4"
+    compare-versions "^3.1.0"
     fileset "^2.0.2"
-    istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-hook "^1.1.0"
-    istanbul-lib-instrument "^1.9.1"
-    istanbul-lib-report "^1.1.2"
-    istanbul-lib-source-maps "^1.2.2"
-    istanbul-reports "^1.1.3"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-hook "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-report "^1.1.4"
+    istanbul-lib-source-maps "^1.2.4"
+    istanbul-reports "^1.3.0"
     js-yaml "^3.7.0"
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
-istanbul-lib-hook@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
+istanbul-lib-hook@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz#f614ec45287b2a8fc4f07f5660af787575601805"
   dependencies:
-    append-transform "^0.4.0"
+    append-transform "^1.0.0"
 
-istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.8.0, istanbul-lib-instrument@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
+istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.8.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
     babylon "^6.18.0"
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.2.0"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
+istanbul-lib-report@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
   dependencies:
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.2.0"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.1, istanbul-lib-source-maps@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
+istanbul-lib-source-maps@^1.2.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
   dependencies:
     debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.1.2"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
+istanbul-lib-source-maps@^1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.2.0"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
   dependencies:
     handlebars "^4.0.3"
 
-jest-changed-files@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.1.4.tgz#1f7844bcb739dec07e5899a633c0cb6d5069834e"
+jest-changed-files@^22.2.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.1.4.tgz#0fe9f3ac881b0cdc00227114c58583a2ebefcc04"
+jest-cli@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.4.4.tgz#68cd2a2aae983adb1e6638248ca21082fd6d9e90"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -1515,21 +1727,22 @@ jest-cli@^22.1.4:
     istanbul-lib-coverage "^1.1.1"
     istanbul-lib-instrument "^1.8.0"
     istanbul-lib-source-maps "^1.2.1"
-    jest-changed-files "^22.1.4"
-    jest-config "^22.1.4"
-    jest-environment-jsdom "^22.1.4"
+    jest-changed-files "^22.2.0"
+    jest-config "^22.4.4"
+    jest-environment-jsdom "^22.4.1"
     jest-get-type "^22.1.0"
-    jest-haste-map "^22.1.0"
-    jest-message-util "^22.1.0"
+    jest-haste-map "^22.4.2"
+    jest-message-util "^22.4.0"
     jest-regex-util "^22.1.0"
     jest-resolve-dependencies "^22.1.0"
-    jest-runner "^22.1.4"
-    jest-runtime "^22.1.4"
-    jest-snapshot "^22.1.2"
-    jest-util "^22.1.4"
-    jest-worker "^22.1.0"
+    jest-runner "^22.4.4"
+    jest-runtime "^22.4.4"
+    jest-snapshot "^22.4.0"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
+    jest-worker "^22.2.2"
     micromatch "^2.3.11"
-    node-notifier "^5.1.2"
+    node-notifier "^5.2.1"
     realpath-native "^1.0.0"
     rimraf "^2.5.4"
     slash "^1.0.0"
@@ -1538,100 +1751,101 @@ jest-cli@^22.1.4:
     which "^1.2.12"
     yargs "^10.0.3"
 
-jest-config@^22.0.1, jest-config@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.1.4.tgz#075ffacce83c3e38cf85b1b9ba0d21bd3ee27ad0"
+jest-config@^22.4.3, jest-config@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.4.4.tgz#72a521188720597169cd8b4ff86934ef5752d86a"
   dependencies:
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^22.1.4"
-    jest-environment-node "^22.1.4"
+    jest-environment-jsdom "^22.4.1"
+    jest-environment-node "^22.4.1"
     jest-get-type "^22.1.0"
-    jest-jasmine2 "^22.1.4"
+    jest-jasmine2 "^22.4.4"
     jest-regex-util "^22.1.0"
-    jest-resolve "^22.1.4"
-    jest-util "^22.1.4"
-    jest-validate "^22.1.2"
-    pretty-format "^22.1.0"
+    jest-resolve "^22.4.2"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
+    pretty-format "^22.4.0"
 
-jest-diff@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.1.0.tgz#0fad9d96c87b453896bf939df3dc8aac6919ac38"
+jest-diff@^22.4.0, jest-diff@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.4.3.tgz#e18cc3feff0aeef159d02310f2686d4065378030"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^22.1.0"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
 
-jest-docblock@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.1.0.tgz#3fe5986d5444cbcb149746eb4b07c57c5a464dfd"
+jest-docblock@^22.4.0, jest-docblock@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
   dependencies:
     detect-newline "^2.1.0"
 
-jest-environment-jsdom@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.1.4.tgz#704518ce8375f7ec5de048d1e9c4268b08a03e00"
+jest-environment-jsdom@^22.4.1:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz#d67daa4155e33516aecdd35afd82d4abf0fa8a1e"
   dependencies:
-    jest-mock "^22.1.0"
-    jest-util "^22.1.4"
+    jest-mock "^22.4.3"
+    jest-util "^22.4.3"
     jsdom "^11.5.1"
 
-jest-environment-node@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.1.4.tgz#0f2946e8f8686ce6c5d8fa280ce1cd8d58e869eb"
+jest-environment-node@^22.4.1:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.4.3.tgz#54c4eaa374c83dd52a9da8759be14ebe1d0b9129"
   dependencies:
-    jest-mock "^22.1.0"
-    jest-util "^22.1.4"
+    jest-mock "^22.4.3"
+    jest-util "^22.4.3"
 
-jest-get-type@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.1.0.tgz#4e90af298ed6181edc85d2da500dbd2753e0d5a9"
+jest-get-type@^22.1.0, jest-get-type@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-jest-haste-map@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.1.0.tgz#1174c6ff393f9818ebf1163710d8868b5370da2a"
+jest-haste-map@^22.4.2:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^22.1.0"
-    jest-worker "^22.1.0"
+    jest-docblock "^22.4.3"
+    jest-serializer "^22.4.3"
+    jest-worker "^22.4.3"
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.1.4.tgz#cada0baf50a220c616a9575728b80d4ddedebe8b"
+jest-jasmine2@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz#c55f92c961a141f693f869f5f081a79a10d24e23"
   dependencies:
-    callsites "^2.0.0"
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^22.1.0"
+    expect "^22.4.0"
     graceful-fs "^4.1.11"
     is-generator-fn "^1.0.0"
-    jest-diff "^22.1.0"
-    jest-matcher-utils "^22.1.0"
-    jest-message-util "^22.1.0"
-    jest-snapshot "^22.1.2"
+    jest-diff "^22.4.0"
+    jest-matcher-utils "^22.4.0"
+    jest-message-util "^22.4.0"
+    jest-snapshot "^22.4.0"
+    jest-util "^22.4.1"
     source-map-support "^0.5.0"
 
-jest-leak-detector@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.1.0.tgz#08376644cee07103da069baac19adb0299b772c2"
+jest-leak-detector@^22.4.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
   dependencies:
-    pretty-format "^22.1.0"
+    pretty-format "^22.4.3"
 
-jest-matcher-utils@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.1.0.tgz#e164665b5d313636ac29f7f6fe9ef0a6ce04febc"
+jest-matcher-utils@^22.4.0, jest-matcher-utils@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^22.1.0"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
 
-jest-message-util@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.1.0.tgz#51ba0794cb6e579bfc4e9adfac452f9f1a0293fc"
+jest-message-util@^22.4.0, jest-message-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.3.tgz#cf3d38aafe4befddbfc455e57d65d5239e399eb7"
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
@@ -1639,59 +1853,60 @@ jest-message-util@^22.1.0:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.1.0.tgz#87ec21c0599325671c9a23ad0e05c86fb5879b61"
+jest-mock@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.4.3.tgz#f63ba2f07a1511772cdc7979733397df770aabc7"
 
-jest-regex-util@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.1.0.tgz#5daf2fe270074b6da63e5d85f1c9acc866768f53"
+jest-regex-util@^22.1.0, jest-regex-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
 
 jest-resolve-dependencies@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz#340e4139fb13315cd43abc054e6c06136be51e31"
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
   dependencies:
-    jest-regex-util "^22.1.0"
+    jest-regex-util "^22.4.3"
 
-jest-resolve@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.1.4.tgz#72b9b371eaac48f84aad4ad732222ffe37692602"
+jest-resolve@^22.4.2:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.4.3.tgz#0ce9d438c8438229aa9b916968ec6b05c1abb4ea"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
 
-jest-runner@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.1.4.tgz#e039039110cb1b31febc0f99e349bf7c94304a2f"
+jest-runner@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.4.4.tgz#dfca7b7553e0fa617e7b1291aeb7ce83e540a907"
   dependencies:
     exit "^0.1.2"
-    jest-config "^22.1.4"
-    jest-docblock "^22.1.0"
-    jest-haste-map "^22.1.0"
-    jest-jasmine2 "^22.1.4"
-    jest-leak-detector "^22.1.0"
-    jest-message-util "^22.1.0"
-    jest-runtime "^22.1.4"
-    jest-util "^22.1.4"
-    jest-worker "^22.1.0"
+    jest-config "^22.4.4"
+    jest-docblock "^22.4.0"
+    jest-haste-map "^22.4.2"
+    jest-jasmine2 "^22.4.4"
+    jest-leak-detector "^22.4.0"
+    jest-message-util "^22.4.0"
+    jest-runtime "^22.4.4"
+    jest-util "^22.4.1"
+    jest-worker "^22.2.2"
     throat "^4.0.0"
 
-jest-runtime@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.1.4.tgz#1474d9f5cda518b702e0b25a17d4ef3fc563a20c"
+jest-runtime@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.4.4.tgz#9ba7792fc75582a5be0f79af6f8fe8adea314048"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^22.1.0"
+    babel-jest "^22.4.4"
     babel-plugin-istanbul "^4.1.5"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     exit "^0.1.2"
     graceful-fs "^4.1.11"
-    jest-config "^22.1.4"
-    jest-haste-map "^22.1.0"
+    jest-config "^22.4.4"
+    jest-haste-map "^22.4.2"
     jest-regex-util "^22.1.0"
-    jest-resolve "^22.1.4"
-    jest-util "^22.1.4"
+    jest-resolve "^22.4.2"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
     json-stable-stringify "^1.0.1"
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
@@ -1700,57 +1915,67 @@ jest-runtime@^22.1.4:
     write-file-atomic "^2.1.0"
     yargs "^10.0.3"
 
-jest-snapshot@^22.1.2:
-  version "22.1.2"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.1.2.tgz#b270cf6e3098f33aceeafda02b13eb0933dc6139"
+jest-serializer@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
+
+jest-snapshot@^22.4.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.4.3.tgz#b5c9b42846ffb9faccb76b841315ba67887362d2"
   dependencies:
     chalk "^2.0.1"
-    jest-diff "^22.1.0"
-    jest-matcher-utils "^22.1.0"
+    jest-diff "^22.4.3"
+    jest-matcher-utils "^22.4.3"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^22.1.0"
+    pretty-format "^22.4.3"
 
-jest-util@^22.1.4:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.1.4.tgz#ac8cbd43ee654102f1941f3f0e9d1d789a8b6a9b"
+jest-util@^22.4.1, jest-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.3.tgz#c70fec8eec487c37b10b0809dc064a7ecf6aafac"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
     is-ci "^1.0.10"
-    jest-message-util "^22.1.0"
-    jest-validate "^22.1.2"
+    jest-message-util "^22.4.3"
     mkdirp "^0.5.1"
+    source-map "^0.6.0"
 
-jest-validate@^22.1.2:
-  version "22.1.2"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.1.2.tgz#c3b06bcba7bd9a850919fe336b5f2a8c3a239404"
+jest-validate@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.4.tgz#1dd0b616ef46c995de61810d85f57119dbbcec4d"
   dependencies:
     chalk "^2.0.1"
+    jest-config "^22.4.4"
     jest-get-type "^22.1.0"
     leven "^2.1.0"
-    pretty-format "^22.1.0"
+    pretty-format "^22.4.0"
 
-jest-worker@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.1.0.tgz#0987832fe58fbdc205357f4c19b992446368cafb"
+jest-worker@^22.2.2, jest-worker@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
   dependencies:
     merge-stream "^1.0.1"
 
 jest@^22.0.2:
-  version "22.1.4"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-22.1.4.tgz#9ec71373a38f40ff92a3e5e96ae85687c181bb72"
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.4.tgz#ffb36c9654b339a13e10b3d4b338eb3e9d49f6eb"
   dependencies:
-    jest-cli "^22.1.4"
+    import-local "^1.0.0"
+    jest-cli "^22.4.4"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.7.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1759,23 +1984,22 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^11.5.1:
-  version "11.6.2"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
+jsdom@^11.10.0, jsdom@^11.5.1:
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
     acorn-globals "^4.1.0"
     array-equal "^1.0.0"
-    browser-process-hrtime "^0.1.2"
-    content-type-parser "^1.0.2"
     cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
+    cssstyle ">= 0.3.1 < 0.4.0"
+    data-urls "^1.0.0"
     domexception "^1.0.0"
     escodegen "^1.9.0"
     html-encoding-sniffer "^1.0.2"
     left-pad "^1.2.0"
-    nwmatcher "^1.4.3"
+    nwsapi "^2.0.0"
     parse5 "4.0.0"
     pn "^1.1.0"
     request "^2.83.0"
@@ -1786,33 +2010,10 @@ jsdom@^11.5.1:
     w3c-hr-time "^1.0.1"
     webidl-conversions "^4.0.2"
     whatwg-encoding "^1.0.3"
-    whatwg-url "^6.4.0"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
     ws "^4.0.0"
     xml-name-validator "^3.0.0"
-
-jsdom@^9.0.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
-  dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
-    array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.79.0"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -1859,7 +2060,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -1870,6 +2071,14 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -1882,8 +2091,8 @@ lcid@^1.0.0:
     invert-kv "^1.0.0"
 
 left-pad@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
 leven@^2.1.0:
   version "2.1.0"
@@ -1917,36 +2126,36 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
-    js-tokens "^3.0.0"
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
 magic-string@^0.22.4:
-  version "0.22.4"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
   dependencies:
-    vlq "^0.2.1"
+    vlq "^0.2.2"
 
 make-error@^1.1.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.3.tgz#a97ae14ffd98b05f543e83ddc395e1b2b6e4cc6a"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -1954,9 +2163,23 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-marked@^0.3.5:
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
+marked@^0.3.17:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
+
+math-random@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -1970,7 +2193,7 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-merge@^1.1.3:
+merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
@@ -1992,15 +2215,33 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
-
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+micromatch@^3.1.4, micromatch@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
-    mime-db "~1.30.0"
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
+mime-db@~1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+
+mime-types@^2.1.12, mime-types@~2.1.17:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  dependencies:
+    mime-db "~1.35.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -2024,7 +2265,27 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1:
+minipass@^2.2.1, minipass@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  dependencies:
+    minipass "^2.2.1"
+
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2034,19 +2295,47 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-nan@^2.3.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+nan@^2.9.2:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+needle@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.1.2:
+node-notifier@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
   dependencies:
@@ -2055,21 +2344,20 @@ node-notifier@^5.1.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.6.39:
-  version "0.6.39"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
   dependencies:
     detect-libc "^1.0.2"
-    hawk "3.1.3"
     mkdirp "^0.5.1"
+    needle "^2.2.1"
     nopt "^4.0.1"
+    npm-packlist "^1.1.6"
     npmlog "^4.0.2"
-    rc "^1.1.7"
-    request "2.81.0"
+    rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
+    tar "^4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -2087,11 +2375,22 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.0, normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+npm-bundled@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
+
+npm-packlist@^1.1.6:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -2112,11 +2411,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.9 < 2.0.0", nwmatcher@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
+nwsapi@^2.0.0:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.7.tgz#6fc54c254621f10cac5225b76e81c74120139b78"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -2124,9 +2423,23 @@ object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
 object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -2142,7 +2455,13 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-once@^1.3.0, once@^1.3.3, once@^1.4.0:
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
+
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -2183,8 +2502,8 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 osenv@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -2194,8 +2513,8 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   dependencies:
     p-try "^1.0.0"
 
@@ -2232,9 +2551,9 @@ parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
-parse5@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -2250,7 +2569,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -2265,10 +2584,6 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -2298,6 +2613,10 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -2307,23 +2626,23 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.4.4:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
-pretty-format@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.1.0.tgz#2277605b40ed4529ae4db51ff62f4be817647914"
+pretty-format@^22.4.0, pretty-format@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.7:
+private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 progress@^2.0.0:
   version "2.0.0"
@@ -2333,34 +2652,35 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
-
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-randomatic@^1.1.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
+randomatic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
   dependencies:
-    is-number "^3.0.0"
-    kind-of "^4.0.0"
+    is-number "^4.0.0"
+    kind-of "^6.0.0"
+    math-random "^1.0.1"
 
-rc@^1.1.7:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
-    deep-extend "~0.4.0"
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -2380,16 +2700,16 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -2402,8 +2722,8 @@ readdirp@^2.0.0:
     set-immediate-shim "^1.0.1"
 
 realpath-native@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.1.tgz#07f40a0cce8f8261e2e8b7ebebf5c95965d7b633"
   dependencies:
     util.promisify "^1.0.0"
 
@@ -2423,6 +2743,13 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -2431,7 +2758,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -2455,36 +2782,9 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2.81.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
-
-request@^2.79.0, request@^2.83.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+request@^2.83.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -2494,7 +2794,6 @@ request@^2.79.0, request@^2.83.0:
     forever-agent "~0.6.1"
     form-data "~2.3.1"
     har-validator "~5.0.3"
-    hawk "~6.0.2"
     http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
@@ -2504,7 +2803,6 @@ request@^2.79.0, request@^2.83.0:
     performance-now "^2.1.0"
     qs "~6.5.1"
     safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
@@ -2536,10 +2834,14 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -2547,15 +2849,15 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
 rollup-plugin-commonjs@^8.0.2:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.3.0.tgz#91b4ba18f340951e39ed7b1901f377a80ab3f9c3"
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.4.1.tgz#5c9cea2b2c3de322f5fbccd147e07ed5e502d7a0"
   dependencies:
     acorn "^5.2.1"
     estree-walker "^0.5.0"
@@ -2564,10 +2866,10 @@ rollup-plugin-commonjs@^8.0.2:
     rollup-pluginutils "^2.0.1"
 
 rollup-plugin-node-resolve@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.2.tgz#38babc12fd404cc2ba1ff68648fe43fa3ffee6b0"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz#c26d110a36812cbefa7ce117cadcd3439aa1c713"
   dependencies:
-    builtin-modules "^1.1.0"
+    builtin-modules "^2.0.0"
     is-module "^1.0.0"
     resolve "^1.1.6"
 
@@ -2588,39 +2890,54 @@ rollup-plugin-typescript2@^0.9.0:
     tslib "^1.8.0"
 
 rollup-pluginutils@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz#478ace04bd7f6da2e724356ca798214884738fc4"
   dependencies:
-    estree-walker "^0.3.0"
+    estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
 rollup@^0.53.0:
   version "0.53.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.53.4.tgz#f92ce56ee1d097ad5b6f13951bc80db5fef18113"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+rsvp@^3.3.3:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
+
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.3.0.tgz#3f3df584abf69e63d4bb74f0f8c42468e4d7d46b"
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
   dependencies:
-    anymatch "^1.3.0"
+    anymatch "^2.0.0"
+    capture-exit "^1.2.0"
     exec-sh "^0.2.0"
     fb-watchman "^2.0.0"
-    minimatch "^3.0.2"
+    micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
     watch "~0.18.0"
   optionalDependencies:
-    fsevents "^1.1.1"
+    fsevents "^1.2.3"
 
-sax@^1.2.1, sax@^1.2.4:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -2631,6 +2948,24 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -2651,9 +2986,9 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.0:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+shelljs@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -2671,23 +3006,38 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
   dependencies:
-    hoek "2.x.x"
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
 
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
   dependencies:
-    hoek "4.x.x"
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
 
 source-map-resolve@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
-    atob "^2.0.0"
+    atob "^2.1.1"
     decode-uri-component "^0.2.0"
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
@@ -2699,10 +3049,11 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
+source-map-support@^0.5.0, source-map-support@^0.5.5:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   dependencies:
+    buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map-url@^0.4.0:
@@ -2715,40 +3066,55 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.6:
+source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-spdx-correct@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
   dependencies:
-    spdx-license-ids "^1.0.2"
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
 
-spdx-expression-parse@~1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
 
-spdx-license-ids@^1.0.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
     dashdash "^1.12.0"
     getpass "^0.1.1"
+    safer-buffer "^2.0.2"
   optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
     ecc-jsbn "~0.1.1"
@@ -2758,6 +3124,13 @@ sshpk@^1.7.0:
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
 
 stealthy-require@^1.1.0:
   version "1.1.1"
@@ -2770,7 +3143,7 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
@@ -2778,22 +3151,18 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
-
-stringstream@~0.0.4, stringstream@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -2841,43 +3210,34 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
-    has-flag "^2.0.0"
+    has-flag "^3.0.0"
 
-symbol-tree@^3.2.1, symbol-tree@^3.2.2:
+symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-tar-pack@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
+tar@^4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
   dependencies:
-    debug "^2.2.0"
-    fstream "^1.0.10"
-    fstream-ignore "^1.0.5"
-    once "^1.3.3"
-    readable-stream "^2.1.4"
-    rimraf "^2.5.1"
-    tar "^2.2.1"
-    uid-number "^0.0.6"
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.3"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
 
-tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
-
-test-exclude@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
+test-exclude@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
   dependencies:
     arrify "^1.0.1"
-    micromatch "^2.3.11"
+    micromatch "^3.1.8"
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
@@ -2894,46 +3254,65 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-to-markdown@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/to-markdown/-/to-markdown-3.1.1.tgz#251e241b8c74c7ad177292e6c52cc195c9268c11"
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
   dependencies:
-    collapse-whitespace "1.1.2"
-    jsdom "^9.0.0"
+    kind-of "^3.0.2"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.2, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+tough-cookie@>=2.3.3, tough-cookie@^2.3.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
+tough-cookie@~2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
 
-tr46@^1.0.0:
+tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
     punycode "^2.1.0"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 ts-jest@^22.0.0:
-  version "22.0.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-22.0.3.tgz#4d30f42c1b26a78d438ad908f9b0bcb4b1e6e32b"
+  version "22.4.6"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-22.4.6.tgz#a5d7f5e8b809626d1f4143209d301287472ec344"
   dependencies:
-    babel-core "^6.24.1"
-    babel-plugin-istanbul "^4.1.4"
-    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
-    babel-preset-jest "^22.0.1"
+    babel-core "^6.26.3"
+    babel-plugin-istanbul "^4.1.6"
+    babel-plugin-transform-es2015-modules-commonjs "^6.26.2"
+    babel-preset-jest "^22.4.3"
     cpx "^1.5.0"
-    fs-extra "4.0.3"
-    jest-config "^22.0.1"
+    fs-extra "6.0.0"
+    jest-config "^22.4.3"
+    lodash "^4.17.10"
     pkg-dir "^2.0.0"
-    source-map-support "^0.5.0"
+    source-map-support "^0.5.5"
     yargs "^11.0.0"
 
 ts-node@^4.1.0:
@@ -2960,31 +3339,35 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.0.0, tslib@^1.8.0, tslib@^1.8.1:
+tslib@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
 tslint-config-prettier@^1.1.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.7.0.tgz#1588f794c6863ba31420e8b1d14ae91326063815"
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.14.0.tgz#860b36634e53f4c70c64c51ff3ef7fd9bbab7676"
 
 tslint-config-standard@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-standard/-/tslint-config-standard-7.0.0.tgz#47bbf25578ed2212456f892d51e1abe884a29f15"
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-standard/-/tslint-config-standard-7.1.0.tgz#6bcc435a179478e365f6cc62312a561221985760"
   dependencies:
-    tslint-eslint-rules "^4.1.1"
+    tslint-eslint-rules "^5.3.1"
 
-tslint-eslint-rules@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz#7c30e7882f26bc276bff91d2384975c69daf88ba"
+tslint-eslint-rules@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz#10dec4361df0b3e4385d91ff8e0226bda4ec2ad4"
   dependencies:
-    doctrine "^0.7.2"
-    tslib "^1.0.0"
-    tsutils "^1.4.0"
+    doctrine "0.7.2"
+    tslib "1.9.0"
+    tsutils "2.8.0"
 
 tslint@^5.8.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -2997,15 +3380,17 @@ tslint@^5.8.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.12.1"
+    tsutils "^2.27.2"
 
-tsutils@^1.4.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
+tsutils@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
+  dependencies:
+    tslib "^1.7.1"
 
-tsutils@^2.12.1:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.21.0.tgz#43466a2283a0abce64e2209bc732ad72f8a04fab"
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:
     tslib "^1.8.1"
 
@@ -3029,41 +3414,41 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
-typedoc-plugin-markdown@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.0.12.tgz#99ec5b5eac0193df42e198093cbaf59d0fe570f7"
+typedoc-plugin-markdown@^1.0.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.1.13.tgz#434ae963156cefaba9dfe3330ce6abf1406ee08d"
   dependencies:
-    to-markdown "^3.1.1"
+    "@forked/turndown" "^4.0.4"
 
-typedoc@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.9.0.tgz#159bff7c7784ce5b91d86f3e4cc8928e62040957"
+typedoc@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.11.1.tgz#9f033887fd2218c769e1045feb88a1efed9f12c9"
   dependencies:
-    "@types/fs-extra" "4.0.0"
-    "@types/handlebars" "4.0.31"
-    "@types/highlight.js" "9.1.8"
-    "@types/lodash" "4.14.74"
+    "@types/fs-extra" "5.0.1"
+    "@types/handlebars" "4.0.36"
+    "@types/highlight.js" "9.12.2"
+    "@types/lodash" "4.14.104"
     "@types/marked" "0.3.0"
-    "@types/minimatch" "2.0.29"
-    "@types/shelljs" "0.7.0"
-    fs-extra "^4.0.0"
+    "@types/minimatch" "3.0.3"
+    "@types/shelljs" "0.7.8"
+    fs-extra "^5.0.0"
     handlebars "^4.0.6"
     highlight.js "^9.0.0"
-    lodash "^4.13.1"
-    marked "^0.3.5"
+    lodash "^4.17.5"
+    marked "^0.3.17"
     minimatch "^3.0.0"
     progress "^2.0.0"
-    shelljs "^0.7.0"
+    shelljs "^0.8.1"
     typedoc-default-themes "^0.5.0"
-    typescript "2.4.1"
+    typescript "2.7.2"
 
-typescript@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
-typescript@~2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@~2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 uglify-js@^2.6:
   version "2.8.29"
@@ -3078,21 +3463,33 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uid-number@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-
-ultron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
 
 universalify@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
 
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -3105,22 +3502,22 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.0.0, uuid@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+uuid@^3.1.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 v8flags@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.1.tgz#dce8fc379c17d9f2c9e9ed78d89ce00052b1b76b"
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.1.tgz#42259a1461c08397e37fe1d4f1cfb59cad85a053"
   dependencies:
     homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
   dependencies:
-    spdx-correct "~1.0.0"
-    spdx-expression-parse "~1.0.0"
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 verror@1.10.0:
   version "1.10.0"
@@ -3130,13 +3527,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vlq@^0.2.1:
+vlq@^0.2.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
-
-void-elements@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"
@@ -3157,11 +3550,7 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-
-webidl-conversions@^4.0.0, webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
+webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -3171,36 +3560,33 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-url@^4.3.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
+whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
-whatwg-url@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+whatwg-url@^6.4.0, whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   dependencies:
     lodash.sortby "^4.7.0"
-    tr46 "^1.0.0"
-    webidl-conversions "^4.0.1"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
 which@^1.2.12, which@^1.2.9, which@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
   dependencies:
-    string-width "^1.0.2"
+    string-width "^1.0.2 || 2"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -3238,16 +3624,11 @@ write-file-atomic@^2.1.0:
     signal-exit "^3.0.2"
 
 ws@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-4.0.0.tgz#bfe1da4c08eeb9780b986e0e4d10eccd7345999f"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-4.1.0.tgz#a979b5d7d4da68bf54efe0408967c324869a7289"
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
-xml-name-validator@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -3260,6 +3641,10 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
 yargs-parser@^8.1.0:
   version "8.1.0"
@@ -3291,8 +3676,8 @@ yargs@^10.0.3:
     yargs-parser "^8.1.0"
 
 yargs@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   dependencies:
     cliui "^4.0.0"
     decamelize "^1.1.1"


### PR DESCRIPTION
Doesn't use any 2.8 or 2.9 specific features yet. Mostly done in preparation for updating to TypeScript 3.0 in the near future.
- Remove edge case tests that were causing trouble with the compiler
- Upgrade packages
- Add missing documentation
- Re-generate docs