### PR TITLE
Cleanups and Additions

### DIFF
--- a/docs/classes/_decoder_.decoder.md
+++ b/docs/classes/_decoder_.decoder.md
@@ -39,6 +39,7 @@ Alternatively, the main decoder `run()` method returns an object of type `Result
 * [constant](_decoder_.decoder.md#constant)
 * [dict](_decoder_.decoder.md#dict)
 * [fail](_decoder_.decoder.md#fail)
+* [intersection](_decoder_.decoder.md#intersection)
 * [lazy](_decoder_.decoder.md#lazy)
 * [number](_decoder_.decoder.md#number)
 * [object](_decoder_.decoder.md#object)
@@ -83,7 +84,7 @@ ___
 **● decode**: *`function`*
 
 #### Type declaration
-▸(json: *`any`*): `Result.Result`<`A`, `Partial`<[DecoderError](../interfaces/_decoder_.decodererror.md)>>
+▸(json: *`any`*): `DecodeResult`<`A`>
 
 **Parameters:**
 
@@ -91,7 +92,7 @@ ___
 | ------ | ------ |
 | json | `any` |
 
-**Returns:** `Result.Result`<`A`, `Partial`<[DecoderError](../interfaces/_decoder_.decodererror.md)>>
+**Returns:** `DecodeResult`<`A`>
 
 ___
 
@@ -178,7 +179,7 @@ ___
 
 ###  run
 
-▸ **run**(json: *`any`*): `Result.Result`<`A`, [DecoderError](../interfaces/_decoder_.decodererror.md)>
+▸ **run**(json: *`any`*): `RunResult`<`A`>
 
 Run the decoder and return a `Result` with either the decoded value or a `DecoderError` containing the json input, the location of the error, and the error message.
 
@@ -207,7 +208,7 @@ string().run(9001)
 | ------ | ------ |
 | json | `any` |
 
-**Returns:** `Result.Result`<`A`, [DecoderError](../interfaces/_decoder_.decodererror.md)>
+**Returns:** `RunResult`<`A`>
 
 ___
 <a id="runpromise"></a>
@@ -252,17 +253,6 @@ ___
 
 Decoder identity function. Useful for incremental decoding.
 
-Example:
-
-```
-const json: any = [1, true, 2, 3, 'five', 4, []];
-const jsonArray: any[] = Result.withDefault([], array(anyJson()).run(json));
-const numbers: number[] = Result.successes(jsonArray.map(number().run));
-
-numbers
-// => [1, 2, 3, 4]
-```
-
 **Returns:** [Decoder](_decoder_.decoder.md)<`any`>
 
 ___
@@ -270,9 +260,11 @@ ___
 
 ### `<Static>` array
 
+▸ **array**(): [Decoder](_decoder_.decoder.md)<`any`[]>
+
 ▸ **array**A(decoder: *[Decoder](_decoder_.decoder.md)<`A`>*): [Decoder](_decoder_.decoder.md)<`A`[]>
 
-Decoder for json arrays. Runs `decoder` on each array element, and succeeds if all elements are successfully decoded.
+Decoder for json arrays. Runs `decoder` on each array element, and succeeds if all elements are successfully decoded. If no `decoder` argument is provided then the outer array part of the json is validated but not the contents, typing the result as `any[]`.
 
 To decode a single value that is inside of an array see `valueAt`.
 
@@ -284,7 +276,22 @@ array(number()).run([1, 2, 3])
 
 array(array(boolean())).run([[true], [], [true, false, false]])
 // => {ok: true, result: [[true], [], [true, false, false]]}
+
+const validNumbersDecoder = array()
+  .map((arr: any[]) => arr.map(number().run))
+  .map(Result.successes)
+
+validNumbersDecoder.run([1, true, 2, 3, 'five', 4, []])
+// {ok: true, result: [1, 2, 3, 4]}
+
+validNumbersDecoder.run([false, 'hi', {}])
+// {ok: true, result: []}
+
+validNumbersDecoder.run(false)
+// {ok: false, error: {..., message: "expected an array, got a boolean"}}
 ```
+
+**Returns:** [Decoder](_decoder_.decoder.md)<`any`[]>
 
 **Type parameters:**
 
@@ -457,6 +464,176 @@ Decoder that ignores the input json and always fails with `errorMessage`.
 **Returns:** [Decoder](_decoder_.decoder.md)<`A`>
 
 ___
+<a id="intersection"></a>
+
+### `<Static>` intersection
+
+▸ **intersection**A,B(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*): [Decoder](_decoder_.decoder.md)< `A` & `B`>
+
+▸ **intersection**A,B,C(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*): [Decoder](_decoder_.decoder.md)< `A` & `B` & `C`>
+
+▸ **intersection**A,B,C,D(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*): [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D`>
+
+▸ **intersection**A,B,C,D,E(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*): [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E`>
+
+▸ **intersection**A,B,C,D,E,F(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*, fd: *[Decoder](_decoder_.decoder.md)<`F`>*): [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E` & `F`>
+
+▸ **intersection**A,B,C,D,E,F,G(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*, fd: *[Decoder](_decoder_.decoder.md)<`F`>*, gd: *[Decoder](_decoder_.decoder.md)<`G`>*): [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E` & `F` & `G`>
+
+▸ **intersection**A,B,C,D,E,F,G,H(ad: *[Decoder](_decoder_.decoder.md)<`A`>*, bd: *[Decoder](_decoder_.decoder.md)<`B`>*, cd: *[Decoder](_decoder_.decoder.md)<`C`>*, dd: *[Decoder](_decoder_.decoder.md)<`D`>*, ed: *[Decoder](_decoder_.decoder.md)<`E`>*, fd: *[Decoder](_decoder_.decoder.md)<`F`>*, gd: *[Decoder](_decoder_.decoder.md)<`G`>*, hd: *[Decoder](_decoder_.decoder.md)<`H`>*): [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E` & `F` & `G` & `H`>
+
+Combines 2-8 object decoders into a decoder for the intersection of all the objects.
+
+Example:
+
+```
+interface Pet {
+  name: string;
+  maxLegs: number;
+}
+
+interface Cat extends Pet {
+  evil: boolean;
+}
+
+const petDecoder: Decoder<Pet> = object({name: string(), maxLegs: number()});
+const catDecoder: Decoder<Cat> = intersection(petDecoder, object({evil: boolean()}));
+```
+
+**Type parameters:**
+
+#### A 
+#### B 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` & `B`>
+
+**Type parameters:**
+
+#### A 
+#### B 
+#### C 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` & `B` & `C`>
+
+**Type parameters:**
+
+#### A 
+#### B 
+#### C 
+#### D 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D`>
+
+**Type parameters:**
+
+#### A 
+#### B 
+#### C 
+#### D 
+#### E 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
+
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E`>
+
+**Type parameters:**
+
+#### A 
+#### B 
+#### C 
+#### D 
+#### E 
+#### F 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](_decoder_.decoder.md)<`F`> |
+
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E` & `F`>
+
+**Type parameters:**
+
+#### A 
+#### B 
+#### C 
+#### D 
+#### E 
+#### F 
+#### G 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](_decoder_.decoder.md)<`F`> |
+| gd | [Decoder](_decoder_.decoder.md)<`G`> |
+
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E` & `F` & `G`>
+
+**Type parameters:**
+
+#### A 
+#### B 
+#### C 
+#### D 
+#### E 
+#### F 
+#### G 
+#### H 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| ad | [Decoder](_decoder_.decoder.md)<`A`> |
+| bd | [Decoder](_decoder_.decoder.md)<`B`> |
+| cd | [Decoder](_decoder_.decoder.md)<`C`> |
+| dd | [Decoder](_decoder_.decoder.md)<`D`> |
+| ed | [Decoder](_decoder_.decoder.md)<`E`> |
+| fd | [Decoder](_decoder_.decoder.md)<`F`> |
+| gd | [Decoder](_decoder_.decoder.md)<`G`> |
+| hd | [Decoder](_decoder_.decoder.md)<`H`> |
+
+**Returns:** [Decoder](_decoder_.decoder.md)< `A` & `B` & `C` & `D` & `E` & `F` & `G` & `H`>
+
+___
 <a id="lazy"></a>
 
 ### `<Static>` lazy
@@ -506,9 +683,11 @@ ___
 
 ### `<Static>` object
 
+▸ **object**(): [Decoder](_decoder_.decoder.md)<`object`>
+
 ▸ **object**A(decoders: *[DecoderObject](../modules/_decoder_.md#decoderobject)<`A`>*): [Decoder](_decoder_.decoder.md)<`A`>
 
-An higher-order decoder that runs decoders on specified fields of an object, and returns a new object with those fields.
+An higher-order decoder that runs decoders on specified fields of an object, and returns a new object with those fields. If `object` is called with no arguments, then the outer object part of the json is validated but not the contents, typing the result as a dictionary where all keys have a value of type `any`.
 
 The `optional` and `constant` decoders are particularly useful for decoding objects that match typescript interfaces.
 
@@ -519,7 +698,12 @@ Example:
 ```
 object({x: number(), y: number()}).run({x: 5, y: 10})
 // => {ok: true, result: {x: 5, y: 10}}
+
+object().map(Object.keys).run({n: 1, i: [], c: {}, e: 'e'})
+// => {ok: true, result: ['n', 'i', 'c', 'e']}
 ```
+
+**Returns:** [Decoder](_decoder_.decoder.md)<`object`>
 
 **Type parameters:**
 

--- a/docs/modules/_combinators_.md
+++ b/docs/modules/_combinators_.md
@@ -8,23 +8,21 @@
 
 * [anyJson](_combinators_.md#anyjson)
 * [array](_combinators_.md#array)
-* [dict](_combinators_.md#dict)
-* [fail](_combinators_.md#fail)
-* [lazy](_combinators_.md#lazy)
-* [oneOf](_combinators_.md#oneof)
-* [optional](_combinators_.md#optional)
-* [succeed](_combinators_.md#succeed)
-* [valueAt](_combinators_.md#valueat)
-* [withDefault](_combinators_.md#withdefault)
-
-### Functions
-
 * [boolean](_combinators_.md#boolean)
 * [constant](_combinators_.md#constant)
+* [dict](_combinators_.md#dict)
+* [fail](_combinators_.md#fail)
+* [intersection](_combinators_.md#intersection)
+* [lazy](_combinators_.md#lazy)
 * [number](_combinators_.md#number)
 * [object](_combinators_.md#object)
+* [oneOf](_combinators_.md#oneof)
+* [optional](_combinators_.md#optional)
 * [string](_combinators_.md#string)
+* [succeed](_combinators_.md#succeed)
 * [union](_combinators_.md#union)
+* [valueAt](_combinators_.md#valueat)
+* [withDefault](_combinators_.md#withdefault)
 
 ---
 
@@ -34,475 +32,153 @@
 
 ### `<Const>` anyJson
 
-**● anyJson**: *`function`* =  Decoder.anyJson
+**● anyJson**: *[anyJson]()* =  Decoder.anyJson
 
 See `Decoder.anyJson`
-
-#### Type declaration
-▸(): [Decoder](../classes/_decoder_.decoder.md)<`any`>
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`any`>
 
 ___
 <a id="array"></a>
 
 ### `<Const>` array
 
-**● array**: *`function`* =  Decoder.array
+**● array**: *[array](../classes/_decoder_.decoder.md#array)* =  Decoder.array
 
 See `Decoder.array`
 
-#### Type declaration
-▸A(decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`[]>
+___
+<a id="boolean"></a>
 
-**Type parameters:**
+### `<Const>` boolean
 
-#### A 
-**Parameters:**
+**● boolean**: *[boolean](../classes/_decoder_.decoder.md#boolean)* =  Decoder.boolean
 
-| Param | Type |
-| ------ | ------ |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
+See `Decoder.boolean`
 
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`[]>
+___
+<a id="constant"></a>
+
+### `<Const>` constant
+
+**● constant**: *[constant](../classes/_decoder_.decoder.md#constant)* =  Decoder.constant
+
+See `Decoder.constant`
 
 ___
 <a id="dict"></a>
 
 ### `<Const>` dict
 
-**● dict**: *`function`* =  Decoder.dict
+**● dict**: *[dict]()* =  Decoder.dict
 
 See `Decoder.dict`
-
-#### Type declaration
-▸A(decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`object`>
-
-**Type parameters:**
-
-#### A 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`object`>
 
 ___
 <a id="fail"></a>
 
 ### `<Const>` fail
 
-**● fail**: *`function`* =  Decoder.fail
+**● fail**: *[fail]()* =  Decoder.fail
 
 See `Decoder.fail`
 
-#### Type declaration
-▸A(errorMessage: *`string`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
+___
+<a id="intersection"></a>
 
-**Type parameters:**
+### `<Const>` intersection
 
-#### A 
-**Parameters:**
+**● intersection**: *[intersection](../classes/_decoder_.decoder.md#intersection)* =  Decoder.intersection
 
-| Param | Type |
-| ------ | ------ |
-| errorMessage | `string` |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
+See `Decoder.intersection`
 
 ___
 <a id="lazy"></a>
 
 ### `<Const>` lazy
 
-**● lazy**: *`function`* =  Decoder.lazy
+**● lazy**: *[lazy]()* =  Decoder.lazy
 
 See `Decoder.lazy`
 
-#### Type declaration
-▸A(mkDecoder: *`function`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
+___
+<a id="number"></a>
 
-**Type parameters:**
+### `<Const>` number
 
-#### A 
-**Parameters:**
+**● number**: *[number](../classes/_decoder_.decoder.md#number)* =  Decoder.number
 
-| Param | Type |
-| ------ | ------ |
-| mkDecoder | `function` |
+See `Decoder.number`
 
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
+___
+<a id="object"></a>
+
+### `<Const>` object
+
+**● object**: *[object](../classes/_decoder_.decoder.md#object)* =  Decoder.object
+
+See `Decoder.object`
 
 ___
 <a id="oneof"></a>
 
 ### `<Const>` oneOf
 
-**● oneOf**: *`function`* =  Decoder.oneOf
+**● oneOf**: *[oneOf]()* =  Decoder.oneOf
 
 See `Decoder.oneOf`
-
-#### Type declaration
-▸A(...decoders: *[Decoder](../classes/_decoder_.decoder.md)<`A`>[]*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-**Type parameters:**
-
-#### A 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| `Rest` decoders | [Decoder](../classes/_decoder_.decoder.md)<`A`>[] |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
 <a id="optional"></a>
 
 ### `<Const>` optional
 
-**● optional**: *`function`* =  Decoder.optional
+**● optional**: *[optional]()* =  Decoder.optional
 
 See `Decoder.optional`
 
-#### Type declaration
-▸A(decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `undefined`>
+___
+<a id="string"></a>
 
-**Type parameters:**
+### `<Const>` string
 
-#### A 
-**Parameters:**
+**● string**: *[string](../classes/_decoder_.decoder.md#string)* =  Decoder.string
 
-| Param | Type |
-| ------ | ------ |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `undefined`>
+See `Decoder.string`
 
 ___
 <a id="succeed"></a>
 
 ### `<Const>` succeed
 
-**● succeed**: *`function`* =  Decoder.succeed
+**● succeed**: *[succeed]()* =  Decoder.succeed
 
 See `Decoder.succeed`
 
-#### Type declaration
-▸A(fixedValue: *`A`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
+___
+<a id="union"></a>
 
-**Type parameters:**
+### `<Const>` union
 
-#### A 
-**Parameters:**
+**● union**: *[union](../classes/_decoder_.decoder.md#union)* =  Decoder.union
 
-| Param | Type |
-| ------ | ------ |
-| fixedValue | `A` |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
+See `Decoder.union`
 
 ___
 <a id="valueat"></a>
 
 ### `<Const>` valueAt
 
-**● valueAt**: *`function`* = 
-  Decoder.valueAt
+**● valueAt**: *[valueAt]()* =  Decoder.valueAt
 
 See `Decoder.valueAt`
-
-#### Type declaration
-▸A(paths: *( `string` &#124; `number`)[]*, decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-**Type parameters:**
-
-#### A 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| paths | ( `string` &#124; `number`)[] |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
 
 ___
 <a id="withdefault"></a>
 
 ### `<Const>` withDefault
 
-**● withDefault**: *`function`* = 
-  Decoder.withDefault
+**● withDefault**: *[withDefault]()* =  Decoder.withDefault
 
 See `Decoder.withDefault`
-
-#### Type declaration
-▸A(defaultValue: *`A`*, decoder: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-**Type parameters:**
-
-#### A 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| defaultValue | `A` |
-| decoder | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-___
-
-## Functions
-
-<a id="boolean"></a>
-
-###  boolean
-
-▸ **boolean**(): [Decoder](../classes/_decoder_.decoder.md)<`boolean`>
-
-See `Decoder.boolean`
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`boolean`>
-
-___
-<a id="constant"></a>
-
-###  constant
-
-▸ **constant**(value: *`true`*): [Decoder](../classes/_decoder_.decoder.md)<`true`>
-
-▸ **constant**(value: *`false`*): [Decoder](../classes/_decoder_.decoder.md)<`false`>
-
-▸ **constant**A(value: *`A`*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-See `Decoder.constant`
-
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| value | `true` |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`true`>
-
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| value | `false` |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`false`>
-
-**Type parameters:**
-
-#### A 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| value | `A` |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-___
-<a id="number"></a>
-
-###  number
-
-▸ **number**(): [Decoder](../classes/_decoder_.decoder.md)<`number`>
-
-See `Decoder.number`
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`number`>
-
-___
-<a id="object"></a>
-
-###  object
-
-▸ **object**A(decoders: *[DecoderObject](_decoder_.md#decoderobject)<`A`>*): [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-See `Decoder.object`
-
-**Type parameters:**
-
-#### A 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| decoders | [DecoderObject](_decoder_.md#decoderobject)<`A`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`A`>
-
-___
-<a id="string"></a>
-
-###  string
-
-▸ **string**(): [Decoder](../classes/_decoder_.decoder.md)<`string`>
-
-See `Decoder.string`
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)<`string`>
-
-___
-<a id="union"></a>
-
-###  union
-
-▸ **union**A,B(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B`>
-
-▸ **union**A,B,C(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C`>
-
-▸ **union**A,B,C,D(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D`>
-
-▸ **union**A,B,C,D,E(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E`>
-
-▸ **union**A,B,C,D,E,F(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*, fd: *[Decoder](../classes/_decoder_.decoder.md)<`F`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F`>
-
-▸ **union**A,B,C,D,E,F,G(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*, fd: *[Decoder](../classes/_decoder_.decoder.md)<`F`>*, gd: *[Decoder](../classes/_decoder_.decoder.md)<`G`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G`>
-
-▸ **union**A,B,C,D,E,F,G,H(ad: *[Decoder](../classes/_decoder_.decoder.md)<`A`>*, bd: *[Decoder](../classes/_decoder_.decoder.md)<`B`>*, cd: *[Decoder](../classes/_decoder_.decoder.md)<`C`>*, dd: *[Decoder](../classes/_decoder_.decoder.md)<`D`>*, ed: *[Decoder](../classes/_decoder_.decoder.md)<`E`>*, fd: *[Decoder](../classes/_decoder_.decoder.md)<`F`>*, gd: *[Decoder](../classes/_decoder_.decoder.md)<`G`>*, hd: *[Decoder](../classes/_decoder_.decoder.md)<`H`>*): [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G` &#124; `H`>
-
-See `Decoder.union`
-
-**Type parameters:**
-
-#### A 
-#### B 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B`>
-
-**Type parameters:**
-
-#### A 
-#### B 
-#### C 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
-| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C`>
-
-**Type parameters:**
-
-#### A 
-#### B 
-#### C 
-#### D 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
-| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
-| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D`>
-
-**Type parameters:**
-
-#### A 
-#### B 
-#### C 
-#### D 
-#### E 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
-| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
-| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
-| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E`>
-
-**Type parameters:**
-
-#### A 
-#### B 
-#### C 
-#### D 
-#### E 
-#### F 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
-| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
-| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
-| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
-| fd | [Decoder](../classes/_decoder_.decoder.md)<`F`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F`>
-
-**Type parameters:**
-
-#### A 
-#### B 
-#### C 
-#### D 
-#### E 
-#### F 
-#### G 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
-| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
-| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
-| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
-| fd | [Decoder](../classes/_decoder_.decoder.md)<`F`> |
-| gd | [Decoder](../classes/_decoder_.decoder.md)<`G`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G`>
-
-**Type parameters:**
-
-#### A 
-#### B 
-#### C 
-#### D 
-#### E 
-#### F 
-#### G 
-#### H 
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| ad | [Decoder](../classes/_decoder_.decoder.md)<`A`> |
-| bd | [Decoder](../classes/_decoder_.decoder.md)<`B`> |
-| cd | [Decoder](../classes/_decoder_.decoder.md)<`C`> |
-| dd | [Decoder](../classes/_decoder_.decoder.md)<`D`> |
-| ed | [Decoder](../classes/_decoder_.decoder.md)<`E`> |
-| fd | [Decoder](../classes/_decoder_.decoder.md)<`F`> |
-| gd | [Decoder](../classes/_decoder_.decoder.md)<`G`> |
-| hd | [Decoder](../classes/_decoder_.decoder.md)<`H`> |
-
-**Returns:** [Decoder](../classes/_decoder_.decoder.md)< `A` &#124; `B` &#124; `C` &#124; `D` &#124; `E` &#124; `F` &#124; `G` &#124; `H`>
 
 ___
 

--- a/docs/modules/_decoder_.md
+++ b/docs/modules/_decoder_.md
@@ -18,7 +18,6 @@
 
 ### Functions
 
-* [decoderErrorString](_decoder_.md#decodererrorstring)
 * [isDecoderError](_decoder_.md#isdecodererror)
 
 ---
@@ -53,23 +52,6 @@ ___
 
 ## Functions
 
-<a id="decodererrorstring"></a>
-
-### `<Const>` decoderErrorString
-
-▸ **decoderErrorString**(error: *[DecoderError](../interfaces/_decoder_.decodererror.md)*): `string`
-
-`DecoderError` information as a formatted string.
-
-**Parameters:**
-
-| Param | Type |
-| ------ | ------ |
-| error | [DecoderError](../interfaces/_decoder_.decodererror.md) |
-
-**Returns:** `string`
-
-___
 <a id="isdecodererror"></a>
 
 ### `<Const>` isDecoderError

--- a/docs/modules/_result_.md
+++ b/docs/modules/_result_.md
@@ -21,6 +21,7 @@
 * [isErr](_result_.md#iserr)
 * [isOk](_result_.md#isok)
 * [map](_result_.md#map)
+* [map2](_result_.md#map2)
 * [mapError](_result_.md#maperror)
 * [ok](_result_.md#ok-1)
 * [successes](_result_.md#successes)
@@ -170,6 +171,31 @@ Apply `f` to the result of an `Ok`, or pass the error through.
 | r | [Result](_result_.md#result)<`A`, `E`> |
 
 **Returns:** [Result](_result_.md#result)<`B`, `E`>
+
+___
+<a id="map2"></a>
+
+### `<Const>` map2
+
+▸ **map2**A,B,C,E(f: *`function`*, ar: *[Result](_result_.md#result)<`A`, `E`>*, br: *[Result](_result_.md#result)<`B`, `E`>*): [Result](_result_.md#result)<`C`, `E`>
+
+Apply `f` to the result of two `Ok`s, or pass an error through. If both `Result`s are errors then the first one is returned.
+
+**Type parameters:**
+
+#### A 
+#### B 
+#### C 
+#### E 
+**Parameters:**
+
+| Param | Type |
+| ------ | ------ |
+| f | `function` |
+| ar | [Result](_result_.md#result)<`A`, `E`> |
+| br | [Result](_result_.md#result)<`B`, `E`> |
+
+**Returns:** [Result](_result_.md#result)<`C`, `E`>
 
 ___
 <a id="maperror"></a>

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
         "statements": 95
       }
     },
-    "collectCoverage": true,
-    "mapCoverage": true
+    "collectCoverage": true
   },
   "devDependencies": {
     "@types/jest": "^22.2.3",

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -55,6 +55,8 @@ export function union(ad: Decoder<any>, bd: Decoder<any>, ...ds: Decoder<any>[])
   return Decoder.oneOf(ad, bd, ...ds);
 }
 
+export const intersection = Decoder.intersection;
+
 /** See `Decoder.withDefault` */
 export const withDefault: <A>(defaultValue: A, decoder: Decoder<A>) => Decoder<A> =
   Decoder.withDefault;

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -1,75 +1,54 @@
-import {Decoder, DecoderObject} from './decoder';
+import {Decoder} from './decoder';
+
+/* tslint:disable:variable-name */
 
 /** See `Decoder.string` */
-export function string(): Decoder<string> {
-  return Decoder.string();
-}
+export const string = Decoder.string;
 
 /** See `Decoder.number` */
-export function number(): Decoder<number> {
-  return Decoder.number();
-}
+export const number = Decoder.number;
 
 /** See `Decoder.boolean` */
-export function boolean(): Decoder<boolean> {
-  return Decoder.boolean();
-}
+export const boolean = Decoder.boolean;
 
 /** See `Decoder.anyJson` */
-export const anyJson: () => Decoder<any> = Decoder.anyJson;
+export const anyJson = Decoder.anyJson;
 
 /** See `Decoder.constant` */
-export function constant(value: true): Decoder<true>;
-export function constant(value: false): Decoder<false>;
-export function constant<A>(value: A): Decoder<A>;
-export function constant(value: any): Decoder<any> {
-  return Decoder.constant(value);
-}
+export const constant = Decoder.constant;
 
 /** See `Decoder.object` */
-export function object<A>(decoders: DecoderObject<A>): Decoder<A> {
-  return Decoder.object(decoders);
-}
+export const object = Decoder.object;
 
 /** See `Decoder.array` */
-export const array: <A>(decoder: Decoder<A>) => Decoder<A[]> = Decoder.array;
+export const array = Decoder.array;
 
 /** See `Decoder.dict` */
-export const dict: <A>(decoder: Decoder<A>) => Decoder<{[name: string]: A}> = Decoder.dict;
+export const dict = Decoder.dict;
 
 /** See `Decoder.optional` */
-export const optional: <A>(decoder: Decoder<A>) => Decoder<A | undefined> = Decoder.optional;
+export const optional = Decoder.optional;
 
 /** See `Decoder.oneOf` */
-export const oneOf: <A>(...decoders: Decoder<A>[]) => Decoder<A> = Decoder.oneOf;
+export const oneOf = Decoder.oneOf;
 
 /** See `Decoder.union` */
-export function union <A, B>(ad: Decoder<A>, bd: Decoder<B>): Decoder<A | B>; // prettier-ignore
-export function union <A, B, C>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>): Decoder<A | B | C>; // prettier-ignore
-export function union <A, B, C, D>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>): Decoder<A | B | C | D>; // prettier-ignore
-export function union <A, B, C, D, E>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>): Decoder<A | B | C | D | E>; // prettier-ignore
-export function union <A, B, C, D, E, F>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>): Decoder<A | B | C | D | E | F>; // prettier-ignore
-export function union <A, B, C, D, E, F, G>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>): Decoder<A | B | C | D | E | F | G>; // prettier-ignore
-export function union <A, B, C, D, E, F, G, H>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>): Decoder<A | B | C | D | E | F | G | H>; // prettier-ignore
-export function union(ad: Decoder<any>, bd: Decoder<any>, ...ds: Decoder<any>[]): Decoder<any> {
-  return Decoder.oneOf(ad, bd, ...ds);
-}
+export const union = Decoder.union;
 
+/** See `Decoder.intersection` */
 export const intersection = Decoder.intersection;
 
 /** See `Decoder.withDefault` */
-export const withDefault: <A>(defaultValue: A, decoder: Decoder<A>) => Decoder<A> =
-  Decoder.withDefault;
+export const withDefault = Decoder.withDefault;
 
 /** See `Decoder.valueAt` */
-export const valueAt: <A>(paths: (string | number)[], decoder: Decoder<A>) => Decoder<A> =
-  Decoder.valueAt;
+export const valueAt = Decoder.valueAt;
 
 /** See `Decoder.succeed` */
-export const succeed: <A>(fixedValue: A) => Decoder<A> = Decoder.succeed;
+export const succeed = Decoder.succeed;
 
 /** See `Decoder.fail` */
-export const fail: <A>(errorMessage: string) => Decoder<A> = Decoder.fail;
+export const fail = Decoder.fail;
 
 /** See `Decoder.lazy` */
-export const lazy: <A>(mkDecoder: () => Decoder<A>) => Decoder<A> = Decoder.lazy;
+export const lazy = Decoder.lazy;

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -43,12 +43,6 @@ export type DecoderObject<A> = {[t in keyof A]: Decoder<A[t]>};
 export const isDecoderError = (a: any): a is DecoderError =>
   a.kind === 'DecoderError' && typeof a.at === 'string' && typeof a.message === 'string';
 
-/**
- * `DecoderError` information as a formatted string.
- */
-export const decoderErrorString = (error: DecoderError): string =>
-  `Input: ${JSON.stringify(error.input)}\nFailed at ${error.at}: ${error.message}`;
-
 /*
  * Helpers
  */
@@ -597,8 +591,7 @@ export class Decoder<A> {
    * Run the decoder and return the value on success, or throw an exception
    * with a formatted error string.
    */
-  runWithException = (json: any): A =>
-    Result.withException(Result.mapError(decoderErrorString, this.run(json)));
+  runWithException = (json: any): A => Result.withException(this.run(json));
 
   /**
    * Construct a new decoder that applies a transformation to the decoded

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -440,6 +440,41 @@ export class Decoder<A> {
   }
 
   /**
+   * Combines 2-8 object decoders into a decoder for the intersection of all the objects.
+   *
+   * Example:
+   * ```
+   * interface Pet {
+   *   name: string;
+   *   maxLegs: number;
+   * }
+   *
+   * interface Cat extends Pet {
+   *   evil: boolean;
+   * }
+   *
+   * const petDecoder: Decoder<Pet> = object({name: string(), maxLegs: number()});
+   * const catDecoder: Decoder<Cat> = intersection(petDecoder, object({evil: boolean()}));
+   * ```
+   */
+  static intersection <A, B>(ad: Decoder<A>, bd: Decoder<B>): Decoder<A & B>; // prettier-ignore
+  static intersection <A, B, C>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>): Decoder<A & B & C>; // prettier-ignore
+  static intersection <A, B, C, D>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>): Decoder<A & B & C & D>; // prettier-ignore
+  static intersection <A, B, C, D, E>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>): Decoder<A & B & C & D & E>; // prettier-ignore
+  static intersection <A, B, C, D, E, F>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>): Decoder<A & B & C & D & E & F>; // prettier-ignore
+  static intersection <A, B, C, D, E, F, G>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>): Decoder<A & B & C & D & E & F & G>; // prettier-ignore
+  static intersection <A, B, C, D, E, F, G, H>(ad: Decoder<A>, bd: Decoder<B>, cd: Decoder<C>, dd: Decoder<D>, ed: Decoder<E>, fd: Decoder<F>, gd: Decoder<G>, hd: Decoder<H>): Decoder<A & B & C & D & E & F & G & H>; // prettier-ignore
+  static intersection(ad: Decoder<any>, bd: Decoder<any>, ...ds: Decoder<any>[]): Decoder<any> {
+    return new Decoder((json: any) =>
+      [ad, bd, ...ds].reduce(
+        (acc: Result.Result<any, Partial<DecoderError>>, decoder) =>
+          Result.map2(Object.assign, acc, decoder.decode(json)),
+        Result.ok({})
+      )
+    );
+  }
+
+  /**
    * Decoder that always succeeds with either the decoded value, or a fallback
    * default value.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   optional,
   oneOf,
   union,
+  intersection,
   withDefault,
   valueAt,
   succeed,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as Result from './result';
 export {Result};
 
-export {Decoder, DecoderError, isDecoderError, decoderErrorString, DecoderObject} from './decoder';
+export {Decoder, DecoderError, isDecoderError, DecoderObject} from './decoder';
 
 export {
   string,

--- a/src/result.ts
+++ b/src/result.ts
@@ -106,6 +106,15 @@ export const map = <A, B, E>(f: (value: A) => B, r: Result<A, E>): Result<B, E> 
   r.ok === true ? ok<B>(f(r.result)) : r;
 
 /**
+ * Apply `f` to the result of two `Ok`s, or pass an error through. If both
+ * `Result`s are errors then the first one is returned.
+ */
+export const map2 = <A, B, C, E>(f: (av: A, bv: B) => C, ar: Result<A, E>, br: Result<B, E>): Result<C, E> =>
+  ar.ok === false ? ar :
+    br.ok === false ? br :
+      ok<C>(f(ar.result, br.result));
+
+/**
  * Apply `f` to the error of an `Err`, or pass the success through.
  */
 export const mapError = <V, A, B>(f: (error: A) => B, r: Result<V, A>): Result<V, B> =>

--- a/src/result.ts
+++ b/src/result.ts
@@ -89,7 +89,7 @@ export const withException = <V>(r: Result<V, any>): V => {
   if (r.ok === true) {
     return r.result;
   } else {
-    throw new Error(r.error);
+    throw r.error;
   }
 };
 

--- a/test/json-decode.test.ts
+++ b/test/json-decode.test.ts
@@ -286,6 +286,24 @@ describe('array', () => {
       });
     });
   });
+
+  it('decodes any array when the array members decoder is not specified', () => {
+    const validNumbersDecoder = array()
+      .map((arr: any[]) => arr.map(number().run))
+      .map(Result.successes);
+
+    expect(validNumbersDecoder.run([1, true, 2, 3, 'five', 4, []])).toEqual({
+      ok: true,
+      result: [1, 2, 3, 4]
+    });
+
+    expect(validNumbersDecoder.run([false, 'hi', {}])).toEqual({ok: true, result: []});
+
+    expect(validNumbersDecoder.run(false)).toMatchObject({
+      ok: false,
+      error: {message: 'expected an array, got a boolean'}
+    });
+  });
 });
 
 describe('dict', () => {

--- a/test/json-decode.test.ts
+++ b/test/json-decode.test.ts
@@ -253,6 +253,15 @@ describe('object', () => {
     expect(decoder.run({a: 12, b: 'hats'})).toEqual({ok: true, result: {a: 12, b: 'hats'}});
     expect(decoder.run({a: 12})).toEqual({ok: true, result: {a: 12}});
   });
+
+  it('decodes any object when the object shape is not specified', () => {
+    const objectKeysDecoder: Decoder<string[]> = object().map(Object.keys);
+
+    expect(objectKeysDecoder.run({n: 1, i: [], c: {}, e: 'e'})).toEqual({
+      ok: true,
+      result: ['n', 'i', 'c', 'e']
+    });
+  });
 });
 
 describe('array', () => {

--- a/test/json-decode.test.ts
+++ b/test/json-decode.test.ts
@@ -682,9 +682,20 @@ describe('runWithException', () => {
   });
 
   it('throws an exception when the decoder fails', () => {
-    expect(() => decoder.runWithException(42)).toThrowError(
-      'Input: 42\nFailed at input: expected a boolean, got a number'
-    );
+    let thrownError: any;
+
+    try {
+      decoder.runWithException(42);
+    } catch (e) {
+      thrownError = e;
+    }
+
+    expect(thrownError).toEqual({
+      kind: 'DecoderError',
+      input: 42,
+      at: 'input',
+      message: 'expected a boolean, got a number'
+    });
   });
 });
 


### PR DESCRIPTION
A couple things to throw in before TS 3.

- Tweak  `Result.withException` and `runWithException` to not use JS's `Error`. I think this is the right thing to do?
   
- `intersection` decoder, mostly for interfaces that extend other interfaces.
   
- `array()` and `object()` return `Decoder<any[]>` and `Decoder<{[key: string]: any}>` respectively. I don't like overloading function types too much, but I think this is a nice convenience because it surfaces functionality that already existed in the less obvious forms of `array(anyJson())` and `dict(anyJson())`. I'd like to experiment with partial decoding more, since an issue that always comes up is what to do when one small part of an object makes the whole decoder fail. After TS 3.0 these functions will return `Decoder<unknown[]>` and `Decoder<{[key: string]: unknown}>`, which will be nice.