### PR TITLE
Fix missing 'lodash' production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,11 @@
   },
   "devDependencies": {
     "@types/jest": "^22.2.3",
-    "@types/lodash": "^4.14.0",
+    "@types/lodash.isequal": "^4.5.3",
     "@types/node": "^10.5.3",
     "colors": "^1.1.2",
     "cross-env": "^5.0.1",
     "jest": "^22.0.2",
-    "lodash": "^4.17.5",
     "prettier": "^1.4.4",
     "rimraf": "^2.6.1",
     "rollup": "^0.53.0",
@@ -84,5 +83,8 @@
     "typedoc": "^0.11.1",
     "typedoc-plugin-markdown": "^1.0.13",
     "typescript": "~2.9.2"
+  },
+  "dependencies": {
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,5 +1,5 @@
 import * as Result from './result';
-const isEqual = require('lodash/isEqual'); // this syntax avoids TS1192
+const isEqual = require('lodash.isequal'); // this syntax avoids TS1192
 
 /**
  * Information describing how json data failed to match a decoder.

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,13 +52,19 @@
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
 
+"@types/lodash.isequal@^4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.3.tgz#b0d2747d3e76cc94da47ebd932c69a98c0ba61b4"
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.116"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
+
 "@types/lodash@4.14.104":
   version "4.14.104"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.104.tgz#53ee2357fa2e6e68379341d92eb2ecea4b11bb80"
-
-"@types/lodash@^4.14.0":
-  version "4.14.114"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.114.tgz#e6f251af5994dd0d7ce141f9241439b4f40270f6"
 
 "@types/marked@0.3.0":
   version "0.3.0"
@@ -2121,6 +2127,10 @@ locate-path@^2.0.0:
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
The package did not declare `lodash` as a production dependency altough it is used in `src/decoder`.

Instead of using the complete `lodash` package we use the small `lodash.isequal` to keep the dependency size small.