### PR TITLE
add strictObject decoder

### DIFF
--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -23,6 +23,9 @@ export const constant = Decoder.constant;
 /** See `Decoder.object` */
 export const object = Decoder.object;
 
+/** See `Decoder.strictObject` */
+export const strictObject = Decoder.strictObject;
+
 /** See `Decoder.array` */
 export const array = Decoder.array;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   unknownJson,
   constant,
   object,
+  strictObject,
   array,
   tuple,
   dict,


### PR DESCRIPTION
This PR addresses #57 and adds a `strictObject` decoder. This decoder is much like the `object` decoder, with the additional behavior of returning an error if the decoded object has *extra* keys that were not defined on the decoder.

Fixes #57 