### PR TITLE
Slim down lodash dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "TypeScript",
     "JSON"
   ],
-  "main": "dist/index.umd.js",
+  "main": "dist/index.js",
   "module": "dist/index.es5.js",
   "typings": "dist/types/index.d.ts",
   "files": [
@@ -62,8 +62,8 @@
   },
   "devDependencies": {
     "@types/jest": "^22.2.3",
-    "@types/lodash.isequal": "^4.5.3",
     "@types/node": "^10.5.3",
+    "@types/lodash": "^4.5.0",
     "colors": "^1.1.2",
     "cross-env": "^5.0.1",
     "jest": "^22.0.2",
@@ -84,6 +84,6 @@
     "typescript": "~3.1.0"
   },
   "dependencies": {
-    "lodash.isequal": "^4.5.0"
+    "lodash": "^4.5.0"
   }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,5 +1,4 @@
 import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import typescript from 'rollup-plugin-typescript2';
 
@@ -7,10 +6,22 @@ const pkg = require('./package.json');
 
 export default {
   input: `src/index.ts`,
-  output: [{file: pkg.main, name: 'index', format: 'umd'}, {file: pkg.module, format: 'es'}],
-  sourcemap: true,
-  // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: [],
+  output: [
+    {
+      file: pkg.main,
+      name: 'index',
+      format: 'cjs',
+      sourcemap: true
+    },
+    {
+      file: pkg.module,
+      format: 'es',
+      sourcemap: true
+    }
+  ],
+  external: id => {
+    return id.includes('/node_modules/');
+  },
   watch: {
     include: 'src/**'
   },
@@ -19,11 +30,6 @@ export default {
     typescript({
       useTsconfigDeclarationDir: true
     }),
-    // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
-    commonjs(),
-    // Allow node_modules resolution, so you can use 'external' to control
-    // which external modules to include in the bundle
-    // https://github.com/rollup/rollup-plugin-node-resolve#usage
     resolve(),
 
     // Resolve source maps to the original source

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,5 +1,5 @@
 import * as Result from './result';
-const isEqual = require('lodash.isequal'); // this syntax avoids TS1192
+import isEqual from "lodash/isEqual"
 
 /**
  * Information describing how json data failed to match a decoder.

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,7 +66,7 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
   integrity sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==
 
-"@types/lodash@^4.14.168":
+"@types/lodash@^4.5.0":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,17 +61,15 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
   integrity sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==
 
-"@types/lodash.isequal@^4.5.3":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.3.tgz#b0d2747d3e76cc94da47ebd932c69a98c0ba61b4"
-  integrity sha512-tpTUmHksO2H9RF98Y2w7v06ZeEKAxHPo2ysL0bV5qv5UBweiZl33NFu5QYmYOSxSnHMqBt/vsVsBVeQAcJiokg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*", "@types/lodash@^4.14.110":
+"@types/lodash@^4.14.110":
   version "4.14.116"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
   integrity sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==
+
+"@types/lodash@^4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/marked@^0.4.0":
   version "0.4.0"
@@ -2422,11 +2420,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -2436,6 +2429,11 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.5.0:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
We replace the `lodash.isequal` dependency with `lodash/isEqual`. This makes it more likely that bundlers can deduplicate this dependency if other dependencies use `lodash` too.

To fully leverage this we also want to properly expose this in the bundles. First, we use the ES Modules `import` so that the module bundle uses it too instead of inlining `require('lodash/isEqual')`. To prevent bundling this dependency we modify the `external` rollup configuration.

We also replace the UMD bundle with a CommonJS bundle. Before, rollup would just inline `require('lodash/isEqual')` so the bundle would not function as a UMD bundle anyways.